### PR TITLE
Feature/version matcher

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,14 +1,6 @@
 module.exports = {
     preset: 'ts-jest',
     testEnvironment: 'node',
-    coverageThreshold: {
-        global: {
-            branches: 70,
-            functions: 80,
-            lines: 86,
-            statements: 85
-        }
-    },
     testPathIgnorePatterns: [
         "tests/static/test.js",
     ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "puzzle-microfrontends",
-  "version": "3.25.1",
+  "version": "3.26.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "logo": "https://image.ibb.co/jM29on/puzzlelogo.png",

--- a/src/configurator.ts
+++ b/src/configurator.ts
@@ -80,7 +80,8 @@ const gatewayFragmentStructure = struct({
     prg: struct.optional('boolean'),
     render: gatewayRenderStructure,
     warden: struct.optional('object'),
-    version: struct.union('string', 'function'),
+    version: 'string',
+    versionMatcher: 'function?',
     versions: struct.dict(['string', gatewayFragmentVersionStructure])
 });
 

--- a/src/configurator.ts
+++ b/src/configurator.ts
@@ -80,7 +80,7 @@ const gatewayFragmentStructure = struct({
     prg: struct.optional('boolean'),
     render: gatewayRenderStructure,
     warden: struct.optional('object'),
-    version: 'string',
+    version: struct.union('string', 'function'),
     versions: struct.dict(['string', gatewayFragmentVersionStructure])
 });
 

--- a/src/configurator.ts
+++ b/src/configurator.ts
@@ -4,6 +4,7 @@ import {IGatewayBFFConfiguration, IStorefrontConfig} from "./types";
 import {ERROR_CODES, PuzzleError} from "./errors";
 import {HTTP_METHODS, INJECTABLE, RESOURCE_INJECT_TYPE, TRANSFER_PROTOCOLS} from "./enums";
 import {RESOURCE_LOADING_TYPE, RESOURCE_TYPE} from "./lib/enums";
+import {CookieVersionMatcher, MATCHER_FN} from "./cookie-version-matcher";
 
 const apiEndpointsStructure = struct({
     path: 'string',
@@ -190,9 +191,11 @@ export class GatewayConfigurator extends Configurator {
     }
 
     protected injectDependencies(configuration: IGatewayBFFConfiguration) {
-        this.injectMiddlewares(configuration);
         this.injectApiHandlers(configuration);
         this.injectCustomDependencies(configuration);
+
+
+        this.prepareFragmentConfiguration(configuration);
     }
 
     private injectApiHandlers(configuration: IGatewayBFFConfiguration) {
@@ -209,7 +212,7 @@ export class GatewayConfigurator extends Configurator {
         });
     }
 
-    private injectMiddlewares(configuration: IGatewayBFFConfiguration) {
+    private prepareFragmentConfiguration(configuration: IGatewayBFFConfiguration) {
         configuration.fragments.forEach(fragment => {
             (Object.values(fragment.versions) as any).forEach((version: any) => {
                 if (version.handler) {
@@ -217,7 +220,8 @@ export class GatewayConfigurator extends Configurator {
                 }
             });
 
-            fragment.render.middlewares = (fragment.render.middlewares as any || []).map((middleware: string) => this.dependencies[INJECTABLE.MIDDLEWARE][middleware]);
+            fragment.render.middlewares = (fragment.render.middlewares as any || [])
+                .map((middleware: string) => this.dependencies[INJECTABLE.MIDDLEWARE][middleware]);
         });
     }
 

--- a/src/cookie-version-matcher.ts
+++ b/src/cookie-version-matcher.ts
@@ -1,0 +1,32 @@
+import {ICookieMap} from "./types";
+
+type MATCHER_FN = (cookies: ICookieMap) => string;
+
+class CookieVersionMatcher {
+    private readonly matcher: MATCHER_FN;
+
+    constructor(matcher: MATCHER_FN | string) {
+        this.matcher = this.parseMatcher(matcher);
+    }
+
+    match(cookies: ICookieMap){
+        return this.matcher(cookies) || null;
+    }
+
+    toJSON() {
+        return this.matcher.toString();
+    }
+
+    private parseMatcher(matcher: MATCHER_FN | string): MATCHER_FN {
+        if (typeof matcher === 'string') {
+            return eval(matcher);
+        }
+
+        return matcher;
+    }
+}
+
+export {
+    MATCHER_FN,
+    CookieVersionMatcher
+};

--- a/src/fragment.ts
+++ b/src/fragment.ts
@@ -50,9 +50,8 @@ export class FragmentBFF extends Fragment {
      * @param {string} version
      * @returns {Promise<HandlerDataResponse>}
      */
-    async render(req: { url: string, headers: object, query: object, params: object }, res: any, version?: string): Promise<HandlerDataResponse> {
-        const targetVersion = version || this.config.version;
-        const handler = this.handler[targetVersion] || this.handler[this.config.version];
+    async render(req: { url: string, headers: object, query: object, params: object }, res: any, version: string): Promise<HandlerDataResponse> {
+        const handler = this.handler[version] || this.handler[this.config.version];
         const clearedRequest = this.clearRequest(req);
         if (handler) {
             if (handler.data) {

--- a/src/fragment.ts
+++ b/src/fragment.ts
@@ -19,6 +19,8 @@ import {decompress} from "iltorb";
 import {Request} from 'express';
 import {HttpClient} from "./client";
 import {ERROR_CODES, PuzzleError} from "./errors";
+import express from "express";
+import {CookieVersionMatcher} from "./cookie-version-matcher";
 
 
 const logger = container.get(TYPES.Logger) as Logger;
@@ -34,11 +36,16 @@ export class Fragment {
 
 export class FragmentBFF extends Fragment {
     config: IFragmentBFF;
+    versionMatcher?: CookieVersionMatcher;
     private handler: { [version: string]: IFragmentHandler } = {};
 
     constructor(config: IFragmentBFF) {
         super({name: config.name});
         this.config = config;
+
+        if (this.config.versionMatcher) {
+            this.versionMatcher = new CookieVersionMatcher(this.config.versionMatcher);
+        }
 
         this.prepareHandlers();
     }
@@ -46,11 +53,10 @@ export class FragmentBFF extends Fragment {
     /**
      * Renders fragment: data -> content
      * @param {object} req
-     * @param res
      * @param {string} version
      * @returns {Promise<HandlerDataResponse>}
      */
-    async render(req: { url: string, headers: object, query: object, params: object }, res: any, version: string): Promise<HandlerDataResponse> {
+    async render(req: express.Request, version: string): Promise<HandlerDataResponse> {
         const handler = this.handler[version] || this.handler[this.config.version];
         const clearedRequest = this.clearRequest(req);
         if (handler) {
@@ -119,7 +125,7 @@ export class FragmentBFF extends Fragment {
      * @param req
      * @returns {*}
      */
-    private clearRequest(req: any) {
+    private clearRequest(req: express.Request) {
         const clearedReq = Object.assign({}, req);
         if (req.query) {
             delete clearedReq.query[RENDER_MODE_QUERY_NAME];
@@ -233,8 +239,7 @@ export class FragmentStorefront extends Fragment {
     /**
      * Returns fragment error as promise, fetches from gateway
      * @returns { Promise<string> }
-     * */
-
+     */
     async getErrorPage(): Promise<string> {
         logger.info(`Trying to get error page of fragment: ${this.name}`);
 
@@ -244,7 +249,7 @@ export class FragmentStorefront extends Fragment {
         }
 
         if (this.cachedErrorPage) {
-            return this.cachedErrorPage
+            return this.cachedErrorPage;
         }
 
         return fetch(`${this.fragmentUrl}/error`, {

--- a/src/fragment.ts
+++ b/src/fragment.ts
@@ -1,6 +1,6 @@
 import fetch from "node-fetch";
 import {
-    HandlerDataResponse,
+    HandlerDataResponse, ICookieMap,
     IExposeFragment,
     IFileResourceAsset,
     IFragment,
@@ -170,6 +170,7 @@ export class FragmentStorefront extends Fragment {
     gatewayPath!: string;
     fragmentUrl: string | undefined;
     assetUrl: string | undefined;
+    private versionMatcher?: CookieVersionMatcher;
     private cachedErrorPage: string | undefined;
     private gatewayName: string;
 
@@ -200,6 +201,28 @@ export class FragmentStorefront extends Fragment {
         this.gatewayName = gatewayName;
 
         this.config = config;
+
+        if (this.config && this.config.versionMatcher) {
+            this.versionMatcher = new CookieVersionMatcher(this.config.versionMatcher);
+        }
+    }
+
+    detectVersion(cookie: ICookieMap, preCompile = false): string {
+        if (!this.config) return '0';
+
+        const cookieKey = this.config.testCookie;
+        const cookieVersion = cookie[cookieKey];
+
+        if (cookieVersion) {
+            return cookieVersion;
+        }
+
+        if (!preCompile && this.versionMatcher) {
+            const version = this.versionMatcher.match(cookie);
+            if (version) return version;
+        }
+
+        return this.config.version;
     }
 
     /**

--- a/src/gatewayBFF.ts
+++ b/src/gatewayBFF.ts
@@ -11,7 +11,7 @@ import {
 } from "./enums";
 import {PREVIEW_PARTIAL_QUERY_NAME, RENDER_MODE_QUERY_NAME} from "./config";
 import {
-    FragmentModel,
+    FragmentModel, ICookieMap,
     IExposeConfig,
     IExposeFragment,
     IFragmentBFF,
@@ -114,6 +114,7 @@ export class GatewayBFF {
             fragments: this.config.fragments.reduce((fragmentList: { [name: string]: IExposeFragment }, fragment) => {
                 fragmentList[fragment.name] = {
                     version: fragment.version,
+                    versionMatcher: fragment.versionMatcher,
                     render: fragment.render,
                     assets: fragment.versions[fragment.version].assets,
                     dependencies: fragment.versions[fragment.version].dependencies,
@@ -148,13 +149,15 @@ export class GatewayBFF {
      * @param {string} fragmentName
      * @param {FRAGMENT_RENDER_MODES} renderMode
      * @param {string} partial
-     * @param {string} cookieValue
+     * @param res
+     * @param cookie
      * @returns {Promise<IFragmentResponse>}
      */
-    async renderFragment(req: any, fragmentName: string, renderMode: FRAGMENT_RENDER_MODES = FRAGMENT_RENDER_MODES.PREVIEW, partial: string, res: any, cookieValue?: string): Promise<void> {
+    async renderFragment(req: any, fragmentName: string, renderMode: FRAGMENT_RENDER_MODES = FRAGMENT_RENDER_MODES.PREVIEW, partial: string, res: any, cookie: ICookieMap): Promise<void> {
         const fragment = this.fragments[fragmentName];
         if (fragment) {
-            const fragmentContent = await fragment.render(req, res, cookieValue);
+            const version = this.detectVersion(fragment, cookie);
+            const fragmentContent = await fragment.render(req, res, version);
 
             const gatewayContent = {
                 content: fragmentContent,
@@ -177,7 +180,7 @@ export class GatewayBFF {
                 } else {
                     if (gatewayContent.content[partial]) {
                         res.status(HTTP_STATUS_CODE.OK);
-                        res.send(this.wrapFragmentContent(gatewayContent.content[partial].toString(), fragment, cookieValue, gatewayContent.$model));
+                        res.send(this.wrapFragmentContent(gatewayContent.content[partial].toString(), fragment, version, gatewayContent.$model));
                     } else {
                         res.status(HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR);
                         res.send(`Partial ${partial} doesn't exist in fragment response`);
@@ -193,14 +196,14 @@ export class GatewayBFF {
      * Wraps with html template for preview mode
      * @param {string} htmlContent
      * @param {FragmentBFF} fragment
-     * @param {string | undefined} cookieValue
+     * @param version
      * @param model
      * @returns {string}
      */
-    private wrapFragmentContent(htmlContent: string, fragment: FragmentBFF, cookieValue: string | undefined, model: FragmentModel): string {
+    private wrapFragmentContent(htmlContent: string, fragment: FragmentBFF, version: string, model: FragmentModel): string {
         const dom = cheerio.load(`<html><head><title>${this.config.name} - ${fragment.name}</title>${this.config.isMobile ? '<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />' : ''}${Template.fragmentModelScript(fragment, model, false)}</head><body><div id="${fragment.name}">${htmlContent}</div></body></html>`);
 
-        const fragmentVersion = cookieValue && fragment.config.versions[cookieValue] ? fragment.config.versions[cookieValue] : fragment.config.versions[fragment.config.version];
+        const fragmentVersion = fragment.config.versions[version];
 
         dom('head').prepend(Template.wrapJsAsset({
             content: fs.readFileSync(path.join(__dirname, `/lib/puzzle.min.js`)).toString(),
@@ -229,6 +232,18 @@ export class GatewayBFF {
         return dom.html();
     }
 
+    private detectVersion(fragment: FragmentBFF, cookie: ICookieMap): string {
+        const cookieKey = fragment.config.testCookie;
+        const cookieVersion = cookie[cookieKey] && fragment.config.versions[cookie[cookieKey]] ? cookie[cookieKey] : null;
+
+        if (cookieVersion) return cookieVersion;
+
+        const matcherVersion = fragment.config.versionMatcher ? fragment.config.versionMatcher.match(cookie) : null;
+        if(matcherVersion && fragment.config.versions[matcherVersion]) return matcherVersion;
+
+        return fragment.config.version;
+    }
+
     /**
      * Adds fragment routes
      * @param {Function} cb
@@ -240,7 +255,7 @@ export class GatewayBFF {
                 const renderMode = req.query[RENDER_MODE_QUERY_NAME] === FRAGMENT_RENDER_MODES.STREAM ? FRAGMENT_RENDER_MODES.STREAM : FRAGMENT_RENDER_MODES.PREVIEW;
                 req.headers['originalurl'] = req.headers['originalurl'] || req.url.replace(`/${fragmentConfig.name}`, "");
                 req.headers['originalpath'] = req.headers['originalpath'] || req.path.replace(`/${fragmentConfig.name}`, "");
-                this.renderFragment(req, fragmentConfig.name, renderMode, partial, res, req.cookies[fragmentConfig.testCookie]);
+                this.renderFragment(req, fragmentConfig.name, renderMode, partial, res, req.cookies);
             }, this.getFragmentMiddlewares(fragmentConfig));
         });
 

--- a/src/gatewayBFF.ts
+++ b/src/gatewayBFF.ts
@@ -153,7 +153,7 @@ export class GatewayBFF {
      * @param cookie
      * @returns {Promise<IFragmentResponse>}
      */
-    async renderFragment(req: any, fragmentName: string, renderMode: FRAGMENT_RENDER_MODES = FRAGMENT_RENDER_MODES.PREVIEW, partial: string, res: any, cookie: ICookieMap): Promise<void> {
+    async renderFragment(req: express.Request, fragmentName: string, renderMode: FRAGMENT_RENDER_MODES = FRAGMENT_RENDER_MODES.PREVIEW, partial: string, res: express.Response, cookie: ICookieMap): Promise<void> {
         const fragment = this.fragments[fragmentName];
         if (fragment) {
             const version = this.detectVersion(fragment, cookie);
@@ -239,7 +239,7 @@ export class GatewayBFF {
         if (cookieVersion) return cookieVersion;
 
         const matcherVersion = fragment.config.versionMatcher ? fragment.config.versionMatcher.match(cookie) : null;
-        if(matcherVersion && fragment.config.versions[matcherVersion]) return matcherVersion;
+        if (matcherVersion && fragment.config.versions[matcherVersion]) return matcherVersion;
 
         return fragment.config.version;
     }
@@ -301,7 +301,7 @@ export class GatewayBFF {
     /**
      *  Adds error routes
      *  @param { Function } cb
-     * */
+     */
     private addErrorPageRoutes(cb: Function): void {
         this.config.fragments.forEach((fragment) => {
             this.server.addRoute(`/${fragment.name}/error`, HTTP_METHODS.GET, (req, res) => {

--- a/src/page.ts
+++ b/src/page.ts
@@ -1,7 +1,7 @@
 import {Template} from "./template";
 import {GatewayStorefrontInstance} from "./gatewayStorefront";
 import {EVENTS} from "./enums";
-import {ICookieObject, IGatewayMap, IPageDependentGateways, IResponseHandlers} from "./types";
+import {ICookieMap, ICookieObject, IGatewayMap, IPageDependentGateways, IResponseHandlers} from "./types";
 import {DEBUG_INFORMATION, DEBUG_QUERY_NAME} from "./config";
 import {container, TYPES} from "./base";
 import {Logger} from "./logger";
@@ -51,7 +51,7 @@ export class Page {
     }
 
     async reCompile() {
-        const defaultVersion = this.getHandlerVersion();
+        const defaultVersion = this.getHandlerVersion({}, true);
         this.responseHandlers[`${defaultVersion}_true`] = await this.template.compile({}, true);
         this.responseHandlers[`${defaultVersion}_false`] = await this.template.compile({}, false);
     }
@@ -89,15 +89,10 @@ export class Page {
      * @param query
      * @param cookies
      */
-    private getHandlerVersion(cookies: { [key: string]: string } = {}) {
+    private getHandlerVersion(cookies: ICookieMap, preCompile = false) {
         return Object.values(this.gatewayDependencies.fragments)
             .reduce((key, fragment) => {
-                if (!fragment.instance.config) {
-                    return `${key}_${fragment.instance.name}|0`;
-                }
-
-                const cookieValue = cookies[fragment.instance.config.testCookie];
-                return `${key}_${fragment.instance.name}|${cookieValue || fragment.instance.config.version}`;
+                return `${key}_${fragment.instance.name}|${fragment.instance.detectVersion(cookies, preCompile)}`;
             }, '');
     }
 

--- a/src/template.ts
+++ b/src/template.ts
@@ -41,9 +41,13 @@ import fs from "fs";
 import path from "path";
 import {IPageFragmentConfig, IPageLibAsset, IPageLibConfiguration, IPageLibDependency} from "./lib/types";
 import {EVENT, RESOURCE_LOADING_TYPE, RESOURCE_TYPE} from "./lib/enums";
+import express from "express";
 
 const logger = container.get(TYPES.Logger) as Logger;
 
+interface CompressionStreamResponse extends express.Response {
+    flush: () => void;
+}
 
 export class Template {
     dom: CheerioStatic;
@@ -451,7 +455,7 @@ export class Template {
     private buildHandler(firstFlushHandler: Function, chunkedFragmentReplacements: IReplaceSet[], waitedFragments: IReplaceSet[] = [], jsReplacements: IReplaceAsset[] = [], isDebug: boolean) {
         //todo primary fragment test et
         if (chunkedFragmentReplacements.length === 0) {
-            return (req: any, res: any) => {
+            return (req: express.Request, res: CompressionStreamResponse) => {
                 this.pageClass._onRequest(req);
                 const fragmentedHtml = firstFlushHandler.call(this.pageClass, req);
                 (async () => {
@@ -470,7 +474,7 @@ export class Template {
                 })();
             };
         } else {
-            return (req: any, res: any) => {
+            return (req: express.Request, res: CompressionStreamResponse) => {
                 this.pageClass._onRequest(req);
                 const fragmentedHtml = firstFlushHandler.call(this.pageClass, req).replace('</body>', '').replace('</html>', '');
                 res.set('transfer-encoding', 'chunked');
@@ -521,7 +525,7 @@ export class Template {
      * @param isDebug
      * @returns {(fragmentContent: IFragmentContentResponse) => void}
      */
-    private flush(chunkedReplacement: IReplaceSet, jsReplacements: IReplaceAsset[], res: any, isDebug: boolean) {
+    private flush(chunkedReplacement: IReplaceSet, jsReplacements: IReplaceAsset[], res: CompressionStreamResponse, isDebug: boolean) {
         return (fragmentContent: IFragmentContentResponse) => {
 
             const fragmentJsReplacements = jsReplacements.find(jsReplacement => jsReplacement.fragment.name === chunkedReplacement.fragment.name);

--- a/src/template.ts
+++ b/src/template.ts
@@ -495,6 +495,7 @@ export class Template {
                         this.pageClass._onResponseEnd();
                     } else {
                         res.write(waitedReplacement.template);
+                        res.flush();
 
                         //Bind flush method to resolved or being resolved promises of chunked replacements
                         Object.values(chunkedFragmentReplacements).forEach((chunkedReplacement, x) => {
@@ -551,6 +552,7 @@ export class Template {
 
             this.pageClass._onChunk(output);
             res.write(output);
+            res.flush();
         };
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -92,14 +92,18 @@ export interface IFragmentBFF extends IFragment {
     versions: {
         [version: string]: IFragmentBFFVersion
     };
-    version: string;
+    version: string | ((cookies: {[key: string]: string}) => string);
     testCookie: string;
     warden?: RouteConfiguration;
     render: IFragmentBFFRender;
 }
 
+
+
 export interface IExposeFragment {
-    version: string;
+    version: string | {
+        fn: (cookies: {[key: string]: string}) => string
+    };
     testCookie: string;
     render: IFragmentBFFRender;
     prg?: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ import {FragmentStorefront} from "./fragment";
 import {Page} from "./page";
 import {RESOURCE_LOADING_TYPE, RESOURCE_TYPE} from "./lib/enums";
 import {RouteConfiguration} from "puzzle-warden/dist/request-manager";
+import {CookieVersionMatcher} from "./cookie-version-matcher";
 
 export interface IFragmentCookieMap {
     name: string;
@@ -92,18 +93,17 @@ export interface IFragmentBFF extends IFragment {
     versions: {
         [version: string]: IFragmentBFFVersion
     };
-    version: string | ((cookies: {[key: string]: string}) => string);
+    version: string;
+    versionMatcher?: CookieVersionMatcher;
     testCookie: string;
     warden?: RouteConfiguration;
     render: IFragmentBFFRender;
 }
 
 
-
 export interface IExposeFragment {
-    version: string | {
-        fn: (cookies: {[key: string]: string}) => string
-    };
+    version: string;
+    versionMatcher?: CookieVersionMatcher;
     testCookie: string;
     render: IFragmentBFFRender;
     prg?: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,7 @@ import {FragmentStorefront} from "./fragment";
 import {Page} from "./page";
 import {RESOURCE_LOADING_TYPE, RESOURCE_TYPE} from "./lib/enums";
 import {RouteConfiguration} from "puzzle-warden/dist/request-manager";
-import {CookieVersionMatcher} from "./cookie-version-matcher";
+import {CookieVersionMatcher, MATCHER_FN} from "./cookie-version-matcher";
 
 export interface IFragmentCookieMap {
     name: string;
@@ -94,7 +94,7 @@ export interface IFragmentBFF extends IFragment {
         [version: string]: IFragmentBFFVersion
     };
     version: string;
-    versionMatcher?: CookieVersionMatcher;
+    versionMatcher?: MATCHER_FN;
     testCookie: string;
     warden?: RouteConfiguration;
     render: IFragmentBFFRender;
@@ -103,7 +103,7 @@ export interface IFragmentBFF extends IFragment {
 
 export interface IExposeFragment {
     version: string;
-    versionMatcher?: CookieVersionMatcher;
+    versionMatcher?: string;
     testCookie: string;
     render: IFragmentBFFRender;
     prg?: boolean;
@@ -152,6 +152,7 @@ export interface IApiConfig {
     name: string;
     testCookie: string;
     liveVersion: string;
+    versionMatcher?: MATCHER_FN;
     versions: { [version: string]: IApiVersion };
 }
 

--- a/tests/cookie-version-matcher.spec.ts
+++ b/tests/cookie-version-matcher.spec.ts
@@ -1,0 +1,1 @@
+import sinon from "sinon";

--- a/tests/cookie-version-matcher.spec.ts
+++ b/tests/cookie-version-matcher.spec.ts
@@ -64,4 +64,22 @@ describe('[cookie-version-matcher.ts]', () => {
         expect(matcherSpy.calledOnce).to.eq(true);
         expect(version).to.eq(cookieVersion);
     });
+
+    it('should return null if matcher fn returns null', () => {
+        // Arrange
+        const matchKey = faker.random.word();
+        const cookieVersion = faker.random.word();
+        const cookies = {
+            [matchKey]: cookieVersion
+        };
+        const matcherSpy = sandbox.stub().withArgs(cookies).returns(null);
+        const matcher = new CookieVersionMatcher(matcherSpy);
+
+        // Act
+        const version = matcher.match(cookies);
+
+        // Assert
+        expect(matcherSpy.calledOnce).to.eq(true);
+        expect(version).to.eq(null);
+    });
 });

--- a/tests/cookie-version-matcher.spec.ts
+++ b/tests/cookie-version-matcher.spec.ts
@@ -1,1 +1,67 @@
-import sinon from "sinon";
+import * as sinon from "sinon";
+import * as faker from "faker";
+import {CookieVersionMatcher} from "../src/cookie-version-matcher";
+import {expect} from "chai";
+
+const sandbox = sinon.createSandbox();
+
+describe('[cookie-version-matcher.ts]', () => {
+    beforeEach(() => {
+
+    });
+
+    afterEach(() => {
+        sandbox.verifyAndRestore();
+    });
+
+    it('should create new CookieVersionMatcher', () => {
+        const matcherFn = sandbox.spy();
+        const matcher = new CookieVersionMatcher(matcherFn);
+
+        expect(matcher).to.be.instanceOf(CookieVersionMatcher);
+    });
+
+    it('should return stringifier of matcher fn', () => {
+        // Arrange
+        const matcherFn = (req: any) => req.cookies['version'];
+        const matcher = new CookieVersionMatcher(matcherFn);
+        const spy = sandbox.spy(matcher, 'toJSON');
+
+        // Act
+        const matcherStringified = JSON.stringify(matcher);
+
+        // Assert
+        expect(spy.calledOnce).to.eq(true);
+        expect(matcherStringified).to.eq(`"(req) => req.cookies['version']"`);
+    });
+
+    it('should parse stringified matcher function to real fn', () => {
+        // Arrange
+        const matcherFn = "(req) => req.cookies['version']";
+        const matcher = new CookieVersionMatcher(matcherFn);
+
+        // Act
+        const matcherStringified = JSON.stringify(matcher);
+
+        // Assert
+        expect(matcherStringified).to.eq(`"${matcherFn}"`);
+    });
+
+    it('should return matcher version', () => {
+        // Arrange
+        const matchKey = faker.random.word();
+        const cookieVersion = faker.random.word();
+        const cookies = {
+            [matchKey]: cookieVersion
+        };
+        const matcherSpy = sandbox.stub().withArgs(cookies).returns(cookieVersion);
+        const matcher = new CookieVersionMatcher(matcherSpy);
+
+        // Act
+        const version = matcher.match(cookies);
+
+        // Assert
+        expect(matcherSpy.calledOnce).to.eq(true);
+        expect(version).to.eq(cookieVersion);
+    });
+});

--- a/tests/fragment.spec.ts
+++ b/tests/fragment.spec.ts
@@ -170,6 +170,18 @@ describe('Fragment', () => {
             expect(fragment.config).to.deep.eq(commonFragmentConfig);
         });
 
+        it('should update fragment configuration with version Matcher', () => {
+            const fragment = new FragmentStorefront('product', 'test');
+            const fragmentConfiguration = {
+                ...commonFragmentConfig,
+                versionMatcher: `(cookies) => '1.2.3'`,
+            };
+            fragment.update(fragmentConfiguration, 'http://local.gatewaysimulator.com', '');
+
+            expect(fragment.config).to.deep.eq(fragmentConfiguration);
+            expect(fragment.detectVersion({})).to.eq('1.2.3');
+        });
+
         it('should fetch placeholder', async () => {
             const placeholderContent = '<div>placeholder</div>';
             const scope = nock('http://local.gatewaysimulator.com')
@@ -231,7 +243,7 @@ describe('Fragment', () => {
 
             const fragment = new FragmentStorefront('product', 'test');
 
-            let fragmentContent = {
+            const fragmentContent = {
                 ...commonFragmentConfig
             };
             fragmentContent.assets = [
@@ -249,7 +261,6 @@ describe('Fragment', () => {
             const scriptContent = await fragment.getAsset('product-bundle', '1.0.0');
 
             expect(scriptContent).to.eq(productScript);
-
         });
 
         it('should log and return empty placeholder when no fragment config exists', (done) => {
@@ -287,6 +298,46 @@ describe('Fragment', () => {
                     done(e);
                 }
             });
+        });
+
+        it('should use version matcher when not pre compiling', () => {
+            const fragment = new FragmentStorefront('product', 'test');
+
+            fragment.update({
+                render: {
+                    placeholder: false,
+                    url: '/'
+                },
+                versionMatcher: `(cookies) => '1.2.3'`,
+                version: '1.0.0',
+                testCookie: 'fragment',
+                dependencies: [],
+                assets: []
+            }, '', '');
+
+            const version = fragment.detectVersion({});
+
+            expect(version).to.eq('1.2.3');
+        });
+
+        it('should use default version matcher when pre compiling', () => {
+            const fragment = new FragmentStorefront('product', 'test');
+
+            fragment.update({
+                render: {
+                    placeholder: false,
+                    url: '/'
+                },
+                versionMatcher: `(cookies) => '1.2.3'`,
+                version: '1.0.0',
+                testCookie: 'fragment',
+                dependencies: [],
+                assets: []
+            }, '', '');
+
+            const version = fragment.detectVersion({}, true);
+
+            expect(version).to.eq('1.0.0');
         });
 
         it('should log and return empty content when no fragment config exists', (done) => {

--- a/tests/fragment.spec.ts
+++ b/tests/fragment.spec.ts
@@ -42,7 +42,7 @@ describe('Fragment', () => {
                 return {data: 'acg'};
             };
             const fragment = new FragmentBFF(fragmentConfig);
-            const response = await fragment.render({} as any, {});
+            const response = await fragment.render({} as any, '1.0.0');
             expect(response).to.deep.eq({
                 main: `acg was here`
             });
@@ -62,7 +62,7 @@ describe('Fragment', () => {
             const fragmentConfig = JSON.parse(JSON.stringify(commonFragmentBffConfiguration));
             fragmentConfig.versions.test.handler.content = (req: any, data: any) => `${data} was here`;
             const fragment = new FragmentBFF(fragmentConfig);
-            fragment.render({} as any, {}).then(data => done(data)).catch(e => {
+            fragment.render({} as any, '1.0.0').then(data => done(data)).catch(e => {
                 expect(e.message).to.include('Failed to find data handler');
                 done();
             });
@@ -77,7 +77,7 @@ describe('Fragment', () => {
                 return {data: 'acg'};
             };
             const fragment = new FragmentBFF(fragmentConfig);
-            fragment.render({} as any, {}, 'no_version').then(data => {
+            fragment.render({} as any, 'no_version').then(data => {
                 expect(data.main).to.include('was here');
                 done();
             });
@@ -136,7 +136,7 @@ describe('Fragment', () => {
             const fragment = new FragmentBFF(fragmentConfig);
 
             try {
-                await fragment.render({} as any, {}, '123');
+                await fragment.render({} as any, '123');
             } catch (err) {
                 return;
             }

--- a/tests/gateway.spec.ts
+++ b/tests/gateway.spec.ts
@@ -7,6 +7,7 @@ import {createExpressMock, createGateway} from "./mock/mock";
 import {GatewayBFF} from "../src/gatewayBFF";
 import {GatewayConfigurator} from "../src/configurator";
 import {DEFAULT_POLLING_INTERVAL} from "../src/config";
+import faker from "faker";
 
 describe('Gateway', () => {
     describe('BFF', () => {
@@ -132,6 +133,119 @@ describe('Gateway', () => {
             expect(bffGw.exposedConfig.hash).to.be.a('string');
         });
 
+        it('should expose public configuration reduced with cookieMatcher', () => {
+            const gatewayConfiguration: IGatewayBFFConfiguration = {
+                ...commonGatewayConfiguration,
+                fragments: [
+                    {
+                        name: 'boutique-list',
+                        version: 'test',
+                        render: {
+                            url: '/'
+                        },
+                        testCookie: 'fragment_test',
+                        versionMatcher: (cookies: any) => '1.0.0',
+                        versions: {
+                            'test': {
+                                assets: [],
+                                dependencies: [],
+                                handler: require('./fragments/boutique-list/test')
+                            },
+                            'test2': {
+                                assets: [],
+                                dependencies: [],
+                                handler: require('./fragments/boutique-list/test2')
+                            }
+                        }
+                    }
+                ]
+            };
+
+            const bffGw = new GatewayBFF(gatewayConfiguration);
+
+            expect(bffGw.exposedConfig).to.deep.include({
+                fragments: {
+                    'boutique-list': {
+                        assets: [],
+                        prg: false,
+                        dependencies: [],
+                        versionMatcher: `(cookies) => '1.0.0'`,
+                        render: {
+                            url: '/'
+                        },
+                        version: 'test',
+                        testCookie: 'fragment_test',
+                        passiveVersions: {
+                            test2: {
+                                assets: [],
+                                dependencies: []
+                            }
+                        }
+                    }
+                }
+            });
+            expect(bffGw.exposedConfig.hash).to.be.a('string');
+        });
+
+        it('should expose public configuration reduced with warden', () => {
+            const wardenConf = {
+                identifier: faker.random.word(),
+                cache: faker.random.boolean(),
+                holder: faker.random.boolean()
+            };
+            const gatewayConfiguration: IGatewayBFFConfiguration = {
+                ...commonGatewayConfiguration,
+                fragments: [
+                    {
+                        name: 'boutique-list',
+                        version: 'test',
+                        render: {
+                            url: '/'
+                        },
+                        testCookie: 'fragment_test',
+                        warden: wardenConf,
+                        versions: {
+                            'test': {
+                                assets: [],
+                                dependencies: [],
+                                handler: require('./fragments/boutique-list/test')
+                            },
+                            'test2': {
+                                assets: [],
+                                dependencies: [],
+                                handler: require('./fragments/boutique-list/test2')
+                            }
+                        }
+                    }
+                ]
+            };
+
+            const bffGw = new GatewayBFF(gatewayConfiguration);
+
+            expect(bffGw.exposedConfig).to.deep.include({
+                fragments: {
+                    'boutique-list': {
+                        assets: [],
+                        prg: false,
+                        dependencies: [],
+                        warden: wardenConf,
+                        render: {
+                            url: '/'
+                        },
+                        version: 'test',
+                        testCookie: 'fragment_test',
+                        passiveVersions: {
+                            test2: {
+                                assets: [],
+                                dependencies: []
+                            }
+                        }
+                    }
+                }
+            });
+            expect(bffGw.exposedConfig.hash).to.be.a('string');
+        });
+
         it('should render fragment in stream mode', async () => {
             const gatewayConfiguration: IGatewayBFFConfiguration = {
                 ...commonGatewayConfiguration,
@@ -155,12 +269,12 @@ describe('Gateway', () => {
             };
 
             const bffGw = new GatewayBFF(gatewayConfiguration);
-            await bffGw.renderFragment({}, 'boutique-list', FRAGMENT_RENDER_MODES.STREAM, DEFAULT_MAIN_PARTIAL, createExpressMock({
+            await bffGw.renderFragment({} as any, 'boutique-list', FRAGMENT_RENDER_MODES.STREAM, DEFAULT_MAIN_PARTIAL, createExpressMock({
                 json: (gwResponse: HandlerDataResponse) => {
                     if (!gwResponse) throw new Error('No response from gateway');
                     expect(gwResponse.main).to.eq('test');
                 }
-            }));
+            }) as any,{});
         });
 
         it('should render fragment in preview mode', async () => {
@@ -186,12 +300,12 @@ describe('Gateway', () => {
             };
 
             const bffGw = new GatewayBFF(gatewayConfiguration);
-            await bffGw.renderFragment({}, 'boutique-list', FRAGMENT_RENDER_MODES.PREVIEW, DEFAULT_MAIN_PARTIAL, createExpressMock({
+            await bffGw.renderFragment({} as any, 'boutique-list', FRAGMENT_RENDER_MODES.PREVIEW, DEFAULT_MAIN_PARTIAL, createExpressMock({
                 send: (gwResponse: string) => {
                     if (!gwResponse) throw new Error('No response from gateway');
                     expect(gwResponse).to.include(`<title>Browsing - boutique-list</title><meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"></head><body><div id="boutique-list">test</div></body></html>`);
                 }
-            }));
+            }) as any,{});
         });
 
         it('should render fragment in preview mode with data passing', async () => {
@@ -231,91 +345,13 @@ describe('Gateway', () => {
             };
 
             const bffGw = new GatewayBFF(gatewayConfiguration);
-            await bffGw.renderFragment({url: 'test'}, 'boutique-list', FRAGMENT_RENDER_MODES.PREVIEW, DEFAULT_MAIN_PARTIAL, createExpressMock({
+            await bffGw.renderFragment({url: 'test'} as any, 'boutique-list', FRAGMENT_RENDER_MODES.PREVIEW, DEFAULT_MAIN_PARTIAL, createExpressMock({
                 send: (gwResponse: string) => {
                     if (!gwResponse) throw new Error('No response from gateway');
                     expect(gwResponse).to.include(`<title>Browsing - boutique-list</title><meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"></head><body><div id="boutique-list">Requested:Url:test</div></body></html>`);
                 }
-            }));
+            }) as any,{});
         });
-
-        // it('should render fragment in preview mode with all assets', async () => {
-        //   const gatewayConfiguration: IGatewayBFFConfiguration = {
-        //     ...commonGatewayConfiguration,
-        //     fragments: [
-        //       {
-        //         name: 'boutique-list',
-        //         version: 'test',
-        //         render: {
-        //           url: '/'
-        //         },
-        //         testCookie: 'fragment_test',
-        //         versions: {
-        //           'test': {
-        //             assets: [
-        //               {
-        //                 fileName: 'head.min.js',
-        //                 type: RESOURCE_TYPE.JS,
-        //                 location: RESOURCE_LOCATION.HEAD,
-        //                 name: 'head'
-        //               },
-        //               {
-        //                 fileName: 'bundle.min.js',
-        //                 type: RESOURCE_TYPE.JS,
-        //                 location: RESOURCE_LOCATION.CONTENT_START,
-        //                 name: 'cs'
-        //               },
-        //               {
-        //                 fileName: 'bundle.min.js',
-        //                 type: RESOURCE_TYPE.JS,
-        //                 location: RESOURCE_LOCATION.BODY_START,
-        //                 name: 'bs'
-        //               },
-        //               {
-        //                 fileName: 'bundle.min.js',
-        //                 type: RESOURCE_TYPE.JS,
-        //                 location: RESOURCE_LOCATION.CONTENT_END,
-        //                 name: 'ce'
-        //               },
-        //               {
-        //                 fileName: 'bundle.min.js',
-        //                 type: RESOURCE_TYPE.JS,
-        //                 location: RESOURCE_LOCATION.BODY_END,
-        //                 name: 'be'
-        //               }
-        //               , {
-        //                 fileName: 'bundle.min.css',
-        //                 type: RESOURCE_TYPE.CSS,
-        //                 location: RESOURCE_LOCATION.HEAD,
-        //                 name: 'headcss'
-        //               },
-        //             ] as IFileResourceAsset[],
-        //             dependencies: [
-        //               {
-        //                 name: 'js',
-        //                 preview: 'preview',
-        //                 type: RESOURCE_TYPE.JS
-        //               }, {
-        //                 name: 'css',
-        //                 preview: 'preview',
-        //                 type: RESOURCE_TYPE.CSS
-        //               }
-        //             ],
-        //             handler: require('./fragments/boutique-list/test')
-        //           }
-        //         }
-        //       }
-        //     ]
-        //   };
-        //
-        //   const bffGw = new GatewayBFF(gatewayConfiguration);
-        //   await bffGw.renderFragment({}, 'boutique-list', FRAGMENT_RENDER_MODES.PREVIEW, DEFAULT_MAIN_PARTIAL, createExpressMock({
-        //     send: (gwResponse: string) => {
-        //       if (!gwResponse) throw new Error('No response from gateway');
-        //       expect(gwResponse).to.eq(`<html><head><title>Browsing - boutique-list</title><meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"><script puzzle-asset="head" src="/boutique-list/static/head.min.js" type="text/javascript"></script><link puzzle-asset="headcss" rel="stylesheet" href="/boutique-list/static/bundle.min.css"><script puzzle-asset="js" src="preview" type="text/javascript"></script><link puzzle-asset="css" rel="stylesheet" href="preview"></head><body><script puzzle-asset="bs" src="/boutique-list/static/bundle.min.js" type="text/javascript"></script><script puzzle-asset="cs" src="/boutique-list/static/bundle.min.js" type="text/javascript"></script><div id="boutique-list">test</div><script puzzle-asset="ce" src="/boutique-list/static/bundle.min.js" type="text/javascript"></script><script puzzle-asset="be" src="/boutique-list/static/bundle.min.js" type="text/javascript"></script></body></html>`);
-        //     }
-        //   }));
-        // });
 
         it('should throw error at render when fragment name not found', done => {
             const gatewayConfiguration: IGatewayBFFConfiguration = {
@@ -340,7 +376,7 @@ describe('Gateway', () => {
             };
 
             const bffGw = new GatewayBFF(gatewayConfiguration);
-            bffGw.renderFragment({}, 'not_exists', FRAGMENT_RENDER_MODES.STREAM, DEFAULT_MAIN_PARTIAL, {}).then(data => done(data)).catch((e) => {
+            bffGw.renderFragment({} as any, 'not_exists', FRAGMENT_RENDER_MODES.STREAM, DEFAULT_MAIN_PARTIAL, {} as any, {}).then(data => done(data)).catch((e) => {
                 expect(e.message).to.include('Failed to find fragment');
                 done();
             });
@@ -390,7 +426,7 @@ describe('Gateway', () => {
             });
         });
 
-        it('should fire gateway ready updated event when hash changed', function (done) {
+        it('should fire gateway ready updated event when hash changed', (done) => {
             const gateway = new GatewayStorefrontInstance(commonGatewayStorefrontConfiguration);
             gateway.startUpdating();
 

--- a/tests/mock/mock.ts
+++ b/tests/mock/mock.ts
@@ -2,37 +2,36 @@ import nock from "nock";
 import {IExposeConfig} from "../../src/types";
 
 export const createGateway = (gatewayName: string, gatewayUrl: string, config: IExposeConfig, persist = false) => {
-  let scope = nock(gatewayUrl);
+    let scope = nock(gatewayUrl);
 
-  if (persist) {
-    scope = scope.persist();
-  }
+    if (persist) {
+        scope = scope.persist();
+    }
 
-  scope = scope
-    .get('/')
-    .reply(200, config);
+    scope = scope
+        .get('/')
+        .reply(200, config);
 
-  return scope;
+    return scope;
 };
 
 
-export const createExpressMock = (extendable?: { write?: Function, json?: Function, end?: Function, set?: Function, status?: Function, send?: Function }) => {
-  const expressMock = {
-      write: extendable && extendable.write || (() => ''),
-      end: extendable && extendable.end || (() => ''),
-      set: extendable && extendable.set || (() => ''),
-      status: (statusCode: number) => {
-        if (extendable && extendable.status) {
-          extendable.status(statusCode);
+export const createExpressMock = (extendable?: { write?: Function, json?: Function, end?: Function, set?: Function, status?: Function, send?: Function, flush?: Function }) => {
+    const expressMock = {
+            write: extendable && extendable.write || (() => ''),
+            end: extendable && extendable.end || (() => ''),
+            set: extendable && extendable.set || (() => ''),
+            status: (statusCode: number) => {
+                if (extendable && extendable.status) {
+                    extendable.status(statusCode);
+                }
+                return expressMock;
+            },
+            json: extendable && extendable.json || (() => ''),
+            send: extendable && extendable.send ? extendable.send : (extendable && extendable.end ? extendable.end : (() => '')),
+            flush: extendable && extendable.flush || (() => {})
         }
-        return expressMock;
-      },
-      json: extendable && extendable.json || (() => ''),
-    send: extendable
-&&
-  extendable.send ? extendable.send : (extendable && extendable.end ? extendable.end : (() => ''))
-}
-  ;
+    ;
 
-  return expressMock;
+    return expressMock;
 };

--- a/tests/mock/mock.ts
+++ b/tests/mock/mock.ts
@@ -17,7 +17,7 @@ export const createGateway = (gatewayName: string, gatewayUrl: string, config: I
 
 
 export const createExpressMock = (extendable?: { write?: Function, json?: Function, end?: Function, set?: Function, status?: Function, send?: Function }) => {
-  let expressMock = {
+  const expressMock = {
       write: extendable && extendable.write || (() => ''),
       end: extendable && extendable.end || (() => ''),
       set: extendable && extendable.set || (() => ''),

--- a/tests/page.spec.ts
+++ b/tests/page.spec.ts
@@ -298,4 +298,39 @@ describe('Page', () => {
             done();
         });
     });
+
+    it('should compile page without fragments cookies (version matcher)', done => {
+        const commonGatewayStorefrontConfiguration = {
+            name: 'Browsing',
+            url: 'http://browsing-gw.com',
+            config: {
+                hash: '44',
+                fragments: {
+                    header: {
+                        version: '1.0.0',
+                        versionMatcher: `cookies => '1.0.1'`,
+                        render: {
+                            url: '/'
+                        },
+                        assets: [],
+                        dependencies: [],
+                        testCookie: 'test_1'
+                    }
+                }
+            }
+        };
+        createGateway(commonGatewayStorefrontConfiguration.name, commonGatewayStorefrontConfiguration.url, commonGatewayStorefrontConfiguration.config, true);
+        const gateway = new GatewayStorefrontInstance(commonGatewayStorefrontConfiguration);
+        const template = fs.readFileSync(path.join(__dirname, './templates/fragmented2.html'), 'utf8');
+        const newPage = new Page(template, {
+            Browsing: gateway,
+        }, 'page');
+
+        gateway.events.on(EVENTS.GATEWAY_READY, async () => {
+            await newPage.reCompile();
+            expect(newPage.responseHandlers).to.haveOwnProperty('_header|1.0.0_content|0_footer|0_true');
+            expect(newPage.responseHandlers).to.haveOwnProperty('_header|1.0.0_content|0_footer|0_false');
+            done();
+        });
+    });
 });


### PR DESCRIPTION
#### What's this PR do?
* Fixes compression flushing
* Provided ab testing ability with version matcher

#### How should this be manually tested?
Add field `versionMatcher: cookies => '2.0.0'`

#### Any background context you want to provide?
To able to build custom smart version selectors like ab testing etc, we need this feature.

#### Demo
```js
        {
            name: "price",
            testCookie: "my-pricing-version",
            versionMatcher: (cookies) => {
                if (cookies['custom_pricing'] === 'enabled') {
                    return '2.0.0'
                }

                return '1.0.0';
            },
            version: "1.0.0",
            versions: {
                "1.0.0": {
                    assets: [],
                    dependencies: []
                },
                "2.0.0": {
                    assets: [],
                    dependencies: []
                }
            },
            render: {
                url: "*"
            }
        }
```
If you have custom_pricing cookie with value enabled then you will receive version 2.0.0.
If you have both my-pricing-version and custom_pricing cookie then test cookie will override versionMatcher

So the order is
1. Test Cookie
2. Version Matcher
3. Default version
