### PR TITLE
implemented to set multiple http cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+# [3.29.0] - 24-5-2019
+### Added
+- Multiple Http Cookies in Header
+
 # [3.28.0] - 23-5-2019
 ### Added
 - Conditional Page Rendering

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "puzzle-microfrontends",
-  "version": "3.28.0",
+  "version": "3.29.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "logo": "https://image.ibb.co/jM29on/puzzlelogo.png",

--- a/src/fragment.ts
+++ b/src/fragment.ts
@@ -316,6 +316,7 @@ export class FragmentStorefront extends Fragment {
                 status: 500,
                 html: {},
                 headers: {},
+                httpCookies: {},
                 model: {}
             };
         }
@@ -368,6 +369,7 @@ export class FragmentStorefront extends Fragment {
             return {
                 status: res.data.$status || res.response.statusCode,
                 headers: res.data.$headers || {},
+                httpCookies: res.data.$httpCookies || {},
                 html: res.data,
                 model: res.data.$model || {}
             };
@@ -380,6 +382,7 @@ export class FragmentStorefront extends Fragment {
                 status: errorPage ? 200 : 500,
                 html: errorPage ? errorPage : {},
                 headers: {},
+                httpCookies: {},
                 model: {}
             };
         });

--- a/src/fragment.ts
+++ b/src/fragment.ts
@@ -316,7 +316,7 @@ export class FragmentStorefront extends Fragment {
                 status: 500,
                 html: {},
                 headers: {},
-                httpCookies: {},
+                cookies: {},
                 model: {}
             };
         }
@@ -369,7 +369,7 @@ export class FragmentStorefront extends Fragment {
             return {
                 status: res.data.$status || res.response.statusCode,
                 headers: res.data.$headers || {},
-                httpCookies: res.data.$httpCookies || {},
+                cookies: res.data.$cookies || {},
                 html: res.data,
                 model: res.data.$model || {}
             };
@@ -382,7 +382,7 @@ export class FragmentStorefront extends Fragment {
                 status: errorPage ? 200 : 500,
                 html: errorPage ? errorPage : {},
                 headers: {},
-                httpCookies: {},
+                cookies: {},
                 model: {}
             };
         });

--- a/src/gatewayBFF.ts
+++ b/src/gatewayBFF.ts
@@ -1,5 +1,5 @@
-import {FragmentBFF} from "./fragment";
-import {Api} from "./api";
+import { FragmentBFF } from "./fragment";
+import { Api } from "./api";
 import {
     CONTENT_REPLACE_SCRIPT,
     DEFAULT_MAIN_PARTIAL,
@@ -10,7 +10,7 @@ import {
     RESOURCE_JS_EXECUTE_TYPE,
     HEALTHCHECK_PATHS,
 } from "./enums";
-import {PREVIEW_PARTIAL_QUERY_NAME, RENDER_MODE_QUERY_NAME} from "./config";
+import { PREVIEW_PARTIAL_QUERY_NAME, RENDER_MODE_QUERY_NAME } from "./config";
 import {
     FragmentModel,
     ICookieMap,
@@ -24,16 +24,16 @@ import md5 from "md5";
 import async from "async";
 import path from "path";
 import express from "express";
-import {Server} from "./server";
-import {container, TYPES} from "./base";
+import { Server } from "./server";
+import { container, TYPES } from "./base";
 import cheerio from "cheerio";
-import {callableOnce, sealed} from "./decorators";
-import {GatewayConfigurator} from "./configurator";
-import {Template} from "./template";
-import {Logger} from "./logger";
+import { callableOnce, sealed } from "./decorators";
+import { GatewayConfigurator } from "./configurator";
+import { Template } from "./template";
+import { Logger } from "./logger";
 import cors from "cors";
 import routeCache from "route-cache";
-import {RESOURCE_TYPE} from "./lib/enums";
+import { RESOURCE_TYPE } from "./lib/enums";
 import fs from "fs";
 
 const logger = container.get(TYPES.Logger) as Logger;
@@ -163,16 +163,21 @@ export class GatewayBFF {
         if (fragment) {
             const version = this.detectVersion(fragment, cookie);
             const fragmentContent = await fragment.render(req, version);
-
+            
             const gatewayContent = {
                 content: fragmentContent,
                 $status: +(fragmentContent.$status || HTTP_STATUS_CODE.OK),
                 $headers: fragmentContent.$headers || {},
+                $httpCookies: fragmentContent.$httpCookies || {},
                 $model: fragmentContent.$model
             };
 
             Object.keys(gatewayContent.$headers).forEach(key => {
                 res.set(key, gatewayContent.$headers[key]);
+            });
+
+            Object.keys(gatewayContent.$httpCookies).forEach(key => {
+                res.cookie(key, gatewayContent.$httpCookies[key].value, gatewayContent.$httpCookies[key].options);
             });
 
             if (renderMode === FRAGMENT_RENDER_MODES.STREAM) {
@@ -366,9 +371,9 @@ export class GatewayBFF {
     private addConfigurationRoute(cb: Function) {
         this.server.addRoute('/', HTTP_METHODS.GET, (req, res) => {
 
-            if(req.query.fragment) {
+            if (req.query.fragment) {
                 const fragment = this.exposedConfig.fragments[req.query.fragment];
-                if(fragment) {
+                if (fragment) {
                     return res.status(HTTP_STATUS_CODE.OK).json({
                         assets: fragment.assets,
                         dependencies: fragment.dependencies,

--- a/src/gatewayBFF.ts
+++ b/src/gatewayBFF.ts
@@ -168,7 +168,7 @@ export class GatewayBFF {
                 content: fragmentContent,
                 $status: +(fragmentContent.$status || HTTP_STATUS_CODE.OK),
                 $headers: fragmentContent.$headers || {},
-                $httpCookies: fragmentContent.$httpCookies || {},
+                $cookies: fragmentContent.$cookies || {},
                 $model: fragmentContent.$model
             };
 
@@ -176,8 +176,8 @@ export class GatewayBFF {
                 res.set(key, gatewayContent.$headers[key]);
             });
 
-            Object.keys(gatewayContent.$httpCookies).forEach(key => {
-                res.cookie(key, gatewayContent.$httpCookies[key].value, gatewayContent.$httpCookies[key].options);
+            Object.keys(gatewayContent.$cookies).forEach(key => {
+                res.cookie(key, gatewayContent.$cookies[key].value, gatewayContent.$cookies[key].options);
             });
 
             if (renderMode === FRAGMENT_RENDER_MODES.STREAM) {

--- a/src/template.ts
+++ b/src/template.ts
@@ -408,7 +408,7 @@ export class Template {
     private async replaceWaitedFragments(waitedFragments: IReplaceSet[], template: string, req: any, isDebug: boolean): Promise<IWaitedResponseFirstFlush> {
         let statusCode = HTTP_STATUS_CODE.OK;
         let headers = {};
-        let httpCookies = {};
+        let cookies = {};
 
         await Promise.all(waitedFragments.map(async waitedFragmentReplacement => {
             const fragmentContent = await waitedFragmentReplacement.fragment.getContent(TemplateCompiler.processExpression(waitedFragmentReplacement.fragmentAttributes, this.pageClass, req), req);
@@ -416,7 +416,7 @@ export class Template {
             if (waitedFragmentReplacement.fragment.primary) {
                 statusCode = fragmentContent.status;
                 headers = fragmentContent.headers;
-                httpCookies = fragmentContent.httpCookies;
+                cookies = fragmentContent.cookies;
             }
 
             waitedFragmentReplacement.replaceItems
@@ -428,7 +428,7 @@ export class Template {
                 });
         }));
 
-        return { template, statusCode, headers, httpCookies };
+        return { template, statusCode, headers, cookies };
     }
 
     /**
@@ -465,11 +465,11 @@ export class Template {
                     for (const prop in waitedReplacement.headers) {
                         res.set(prop, waitedReplacement.headers[prop]);
                     }
-                    for (const prop in waitedReplacement.httpCookies) {
-                        if(waitedReplacement.httpCookies[prop].options && waitedReplacement.httpCookies[prop].options.expires){
-                            waitedReplacement.httpCookies[prop].options.expires = new Date(String(waitedReplacement.httpCookies[prop].options.expires));
+                    for (const prop in waitedReplacement.cookies) {
+                        if(waitedReplacement.cookies[prop].options && waitedReplacement.cookies[prop].options.expires){
+                            waitedReplacement.cookies[prop].options.expires = new Date(String(waitedReplacement.cookies[prop].options.expires));
                         }
-                        res.cookie(prop, waitedReplacement.httpCookies[prop].value, waitedReplacement.httpCookies[prop].options);
+                        res.cookie(prop, waitedReplacement.cookies[prop].value, waitedReplacement.cookies[prop].options);
                     }
                     res.status(waitedReplacement.statusCode);
                     if (waitedReplacement.statusCode === HTTP_STATUS_CODE.MOVED_PERMANENTLY) {
@@ -501,8 +501,8 @@ export class Template {
                     for (const prop in waitedReplacement.headers) {
                         res.set(prop, waitedReplacement.headers[prop]);
                     }
-                    for (const prop in waitedReplacement.httpCookies) {
-                        res.cookie(prop, waitedReplacement.httpCookies[prop].value, waitedReplacement.httpCookies[prop].options);
+                    for (const prop in waitedReplacement.cookies) {
+                        res.cookie(prop, waitedReplacement.cookies[prop].value, waitedReplacement.cookies[prop].options);
                     }
                     res.status(waitedReplacement.statusCode);
                     if (waitedReplacement.statusCode === HTTP_STATUS_CODE.MOVED_PERMANENTLY) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,7 @@ import {Page} from "./page";
 import {RESOURCE_LOADING_TYPE, RESOURCE_TYPE} from "./lib/enums";
 import {RouteConfiguration} from "puzzle-warden/dist/request-manager";
 import {MATCHER_FN} from "./cookie-version-matcher";
-import express from "express";
+import express, { CookieOptions } from "express";
 
 export interface IFragmentCookieMap {
     name: string;
@@ -182,6 +182,15 @@ export interface ICookieObject {
     [name: string]: string;
 }
 
+export interface IHttpCookie {
+    value: string;
+    options: CookieOptions
+}
+
+export interface IHttpCookieMap {
+    [key: string]: IHttpCookie
+}
+
 export interface IFragmentContentResponse {
     status: number;
     html: {
@@ -190,6 +199,7 @@ export interface IFragmentContentResponse {
     headers: {
         [name: string]: string;
     };
+    httpCookies: IHttpCookieMap;
     model: FragmentModel;
 }
 
@@ -293,6 +303,7 @@ export interface IWaitedResponseFirstFlush {
     headers: {
         [name: string]: string;
     };
+    httpCookies: IHttpCookieMap;
 }
 
 export interface IApiHandlerModule {

--- a/src/types.ts
+++ b/src/types.ts
@@ -199,7 +199,7 @@ export interface IFragmentContentResponse {
     headers: {
         [name: string]: string;
     };
-    httpCookies: IHttpCookieMap;
+    cookies: IHttpCookieMap;
     model: FragmentModel;
 }
 
@@ -303,7 +303,7 @@ export interface IWaitedResponseFirstFlush {
     headers: {
         [name: string]: string;
     };
-    httpCookies: IHttpCookieMap;
+    cookies: IHttpCookieMap;
 }
 
 export interface IApiHandlerModule {

--- a/tests/fragment.spec.ts
+++ b/tests/fragment.spec.ts
@@ -349,6 +349,7 @@ describe('Fragment', () => {
                         status: 500,
                         html: {},
                         headers: {},
+                        httpCookies: {},
                         model: {}
                     });
                     done();

--- a/tests/fragment.spec.ts
+++ b/tests/fragment.spec.ts
@@ -349,7 +349,7 @@ describe('Fragment', () => {
                         status: 500,
                         html: {},
                         headers: {},
-                        httpCookies: {},
+                        cookies: {},
                         model: {}
                     });
                     done();

--- a/tests/integration/bff.spec.ts
+++ b/tests/integration/bff.spec.ts
@@ -500,6 +500,8 @@ describe('BFF', () => {
     });
 
     it('should export fragment 404 content in stream mode with header', (done) => {
+        const customHttpCookieExpiredDate = new Date(Date.now() + 1000 * 60 * 60 * 4);
+
         const bff = new GatewayBFF({
             ...commonGatewayConfiguration,
             fragments: [
@@ -528,6 +530,17 @@ describe('BFF', () => {
                                         $status: 404,
                                         $headers: {
                                             'failure': 'reason',
+                                        },
+                                        $httpCookies: {
+                                            customHttpCookie1: {
+                                                value: 'customValue1',
+                                                options: {
+                                                    expires: customHttpCookieExpiredDate
+                                                }
+                                            },
+                                            customHttpCookie2: {
+                                                value: 'customValue2'
+                                            }
                                         }
                                     };
                                 },
@@ -553,8 +566,13 @@ describe('BFF', () => {
                     expect(res.body).to.deep.eq({
                         "main": "<div>Rendered Fragment Fragment</div>",
                         '$status': 404,
-                        '$headers': {failure: 'reason'}
-                    });
+                        '$headers': {failure: 'reason'},
+                        '$httpCookies':
+                            { customHttpCookie1: { value: 'customValue1', options: { expires: customHttpCookieExpiredDate.toISOString() } },
+                              customHttpCookie2: { value: 'customValue2' } } }
+                    );
+                    expect(res.header['set-cookie'][0]).to.eq(`customHttpCookie1=customValue1; Path=/; Expires=${customHttpCookieExpiredDate.toUTCString()}`);
+                    expect(res.header['set-cookie'][1]).to.eq(`customHttpCookie2=customValue2; Path=/`);
                     done();
                 });
         });

--- a/tests/integration/bff.spec.ts
+++ b/tests/integration/bff.spec.ts
@@ -500,7 +500,7 @@ describe('BFF', () => {
     });
 
     it('should export fragment 404 content in stream mode with header', (done) => {
-        const customHttpCookieExpiredDate = new Date(Date.now() + 1000 * 60 * 60 * 4);
+        const customCookieExpiredDate = new Date(Date.now() + 1000 * 60 * 60 * 4);
 
         const bff = new GatewayBFF({
             ...commonGatewayConfiguration,
@@ -531,14 +531,14 @@ describe('BFF', () => {
                                         $headers: {
                                             'failure': 'reason',
                                         },
-                                        $httpCookies: {
-                                            customHttpCookie1: {
+                                        $cookies: {
+                                            customCookie1: {
                                                 value: 'customValue1',
                                                 options: {
-                                                    expires: customHttpCookieExpiredDate
+                                                    expires: customCookieExpiredDate
                                                 }
                                             },
-                                            customHttpCookie2: {
+                                            customCookie2: {
                                                 value: 'customValue2'
                                             }
                                         }
@@ -567,12 +567,12 @@ describe('BFF', () => {
                         "main": "<div>Rendered Fragment Fragment</div>",
                         '$status': 404,
                         '$headers': {failure: 'reason'},
-                        '$httpCookies':
-                            { customHttpCookie1: { value: 'customValue1', options: { expires: customHttpCookieExpiredDate.toISOString() } },
-                              customHttpCookie2: { value: 'customValue2' } } }
+                        '$cookies':
+                            { customCookie1: { value: 'customValue1', options: { expires: customCookieExpiredDate.toISOString() } },
+                              customCookie2: { value: 'customValue2' } } }
                     );
-                    expect(res.header['set-cookie'][0]).to.eq(`customHttpCookie1=customValue1; Path=/; Expires=${customHttpCookieExpiredDate.toUTCString()}`);
-                    expect(res.header['set-cookie'][1]).to.eq(`customHttpCookie2=customValue2; Path=/`);
+                    expect(res.header['set-cookie'][0]).to.eq(`customCookie1=customValue1; Path=/; Expires=${customCookieExpiredDate.toUTCString()}`);
+                    expect(res.header['set-cookie'][1]).to.eq(`customCookie2=customValue2; Path=/`);
                     done();
                 });
         });

--- a/tests/system/system.spec.ts
+++ b/tests/system/system.spec.ts
@@ -286,7 +286,7 @@ describe('System Tests', function () {
 
   it('should render single fragment with header', function (done) {
     const gatewayConfigurator = new GatewayConfigurator();
-    const customHttpCookieExpiredDate = new Date(Date.now() + 1000 * 60 * 60 * 4);
+    const customCookieExpiredDate = new Date(Date.now() + 1000 * 60 * 60 * 4);
 
     gatewayConfigurator.register('handler', INJECTABLE.HANDLER, {
       data() {
@@ -295,14 +295,14 @@ describe('System Tests', function () {
           $headers: {
             custom: 'custom value'
           },
-          $httpCookies: {
-            customHttpCookie1: {
+          $cookies: {
+            customCookie1: {
               value: 'customValue1',
               options: {
-                expires: customHttpCookieExpiredDate
+                expires: customCookieExpiredDate
               }
             },
-            customHttpCookie2: {
+            customCookie2: {
               value: 'customValue2'
             }
           }
@@ -378,8 +378,8 @@ describe('System Tests', function () {
               closeInstance(storefrontInstance);
               closeInstance(gatewayInstance);
               expect(res.header['custom']).to.eq('custom value');
-              expect(res.header['set-cookie'][0]).to.eq(`customHttpCookie1=customValue1; Path=/; Expires=${customHttpCookieExpiredDate.toUTCString()}`);
-              expect(res.header['set-cookie'][1]).to.eq(`customHttpCookie2=customValue2; Path=/`);
+              expect(res.header['set-cookie'][0]).to.eq(`customCookie1=customValue1; Path=/; Expires=${customCookieExpiredDate.toUTCString()}`);
+              expect(res.header['set-cookie'][1]).to.eq(`customCookie2=customValue2; Path=/`);
               expect(res.text).to.include(`<body><div id="example" puzzle-fragment="example" puzzle-gateway="Browsing">Fragment Content</div>`);
               done(err);
             });

--- a/tests/system/system.spec.ts
+++ b/tests/system/system.spec.ts
@@ -1,13 +1,13 @@
-import {expect} from "chai";
-import {Storefront} from "../../src/storefront";
+import { expect } from "chai";
+import { Storefront } from "../../src/storefront";
 import request from "supertest";
-import {GatewayBFF} from "../../src/gatewayBFF";
+import { GatewayBFF } from "../../src/gatewayBFF";
 import path from "path";
-import {GatewayConfigurator} from "../../src/configurator";
+import { GatewayConfigurator } from "../../src/configurator";
 import faker from "faker";
-import {CONTENT_REPLACE_SCRIPT, INJECTABLE, PUZZLE_LIB_SCRIPT, TRANSFER_PROTOCOLS} from "../../src/enums";
-import {TLS_CERT, TLS_KEY, TLS_PASS} from "../core.settings";
-import {EVENT} from "../../src/lib/enums";
+import { CONTENT_REPLACE_SCRIPT, INJECTABLE, PUZZLE_LIB_SCRIPT, TRANSFER_PROTOCOLS } from "../../src/enums";
+import { TLS_CERT, TLS_KEY, TLS_PASS } from "../core.settings";
+import { EVENT } from "../../src/lib/enums";
 
 describe('System Tests', function () {
   const closeInstance = (instance: any) => {
@@ -286,12 +286,25 @@ describe('System Tests', function () {
 
   it('should render single fragment with header', function (done) {
     const gatewayConfigurator = new GatewayConfigurator();
+    const customHttpCookieExpiredDate = new Date(Date.now() + 1000 * 60 * 60 * 4);
+
     gatewayConfigurator.register('handler', INJECTABLE.HANDLER, {
       data() {
         return {
           data: {},
           $headers: {
             custom: 'custom value'
+          },
+          $httpCookies: {
+            customHttpCookie1: {
+              value: 'customValue1',
+              options: {
+                expires: customHttpCookieExpiredDate
+              }
+            },
+            customHttpCookie2: {
+              value: 'customValue2'
+            }
           }
         };
       },
@@ -365,6 +378,8 @@ describe('System Tests', function () {
               closeInstance(storefrontInstance);
               closeInstance(gatewayInstance);
               expect(res.header['custom']).to.eq('custom value');
+              expect(res.header['set-cookie'][0]).to.eq(`customHttpCookie1=customValue1; Path=/; Expires=${customHttpCookieExpiredDate.toUTCString()}`);
+              expect(res.header['set-cookie'][1]).to.eq(`customHttpCookie2=customValue2; Path=/`);
               expect(res.text).to.include(`<body><div id="example" puzzle-fragment="example" puzzle-gateway="Browsing">Fragment Content</div>`);
               done(err);
             });


### PR DESCRIPTION
#### What's this PR do?
- Regarding to HTTP RFC standarts, 

> Origin servers SHOULD NOT fold multiple Set-Cookie header fields into
   a single header field. [https://tools.ietf.org/html/rfc6265#section-3](RFC6265)

By the way, we cannot use 
```
return {
      data: data,
      $header: {
          'Set-Cookie': 'cookieKey1=cookieValue1; Max-Age=900000; Path=/;'
      }
    }
```
to create multiple 'Set-Cookie' header values.

To figure it out we need to set 'Set-Cookie' header more than times. Now, puzzle-js handle this for us like this:

```
return {
      data: data,
      $httpCookies: {
        cookieKey1: {
          value: cookieValue1,
          options: {
            maxAge: 900000
          }
        },
        cookieKey2: {
          value: cookieValue2,
          expires: 0
        }
      }
    }
```

**options** fields structure comes from express **CookieOptions** type. More detail [https://expressjs.com/en/4x/api.html#res.cookie](express-cookie)