### PR TITLE
express-serve-static-core moved to dependencies, problem fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "puzzle-microfrontends",
-  "version": "3.31.4",
+  "version": "3.31.5",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "logo": "https://image.ibb.co/jM29on/puzzlelogo.png",
@@ -20,7 +20,6 @@
     "@types/cookie-parser": "^1.4.1",
     "@types/cors": "^2.8.4",
     "@types/express": "^4.11.1",
-    "@types/express-serve-static-core": "^4.16.7",
     "@types/faker": "^4.1.2",
     "@types/helmet": "0.0.37",
     "@types/jest": "^24.0.15",
@@ -32,7 +31,6 @@
     "@types/node-fetch": "^2.3.3",
     "@types/request": "^2.47.1",
     "@types/response-time": "^2.3.3",
-    "@types/serve-static": "^1.13.2",
     "@types/sinon": "^7.0.13",
     "@types/spdy": "^3.4.4",
     "@types/supertest": "^2.0.4",
@@ -69,6 +67,8 @@
     "lint:ts:fix": "./node_modules/.bin/tslint -p ./tsconfig.json --fix"
   },
   "dependencies": {
+    "@types/serve-static": "^1.13.2",
+    "@types/express-serve-static-core": "^4.16.7",
     "async": "^3.0.1",
     "cheerio": "^1.0.0-rc.2",
     "clean-css": "^4.1.11",


### PR DESCRIPTION
#### What's this PR do?
* - @types/express-serve-static-core should not be devDep, this is a hotfix we will work on this in future, we do not need to depend on this library.