### PR TITLE
Version: 3.32.8 - Fix/request header 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+# [3.32.8] - 27-10-2020
+### Fixed
+- RequestConfiguration header host is deleted because it caused some unintentional behaviours.
+
 # [3.32.7] - 01-8-2019
 ### Fixed
 - CheerioStatic type is changed to any

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puzzle-js/core",
-  "version": "2.8.5",
+  "version": "3.32.8",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "logo": "https://image.ibb.co/jM29on/puzzlelogo.png",

--- a/src/fragment.ts
+++ b/src/fragment.ts
@@ -368,6 +368,7 @@ export class FragmentStorefront extends Fragment {
       }
       if (req.headers) {
         requestConfiguration.headers = req.headers;
+        delete requestConfiguration.headers.host;
         requestConfiguration.headers['originalurl'] = req.url;
         requestConfiguration.headers['originalpath'] = req.path;
       }


### PR DESCRIPTION
#### What's this PR do?
* Delete host header so the controller would not redirect.
#### Where should the reviewer start?
* In every function calling fragment.ts getContent.
#### How should this be manually tested?
* The bug can be repeated by giving a condition function to a controller and then returning false.
#### Any background context you want to provide?
* -
#### What are the relevant tickets?
* -
#### Screenshots (if appropriate)
* -

**Npm/Changelog and package.json version is synced to 3.32.8**
