### PR TITLE
seperate partials and main placeholder for client-async mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
-
+# [3.46.0] - 23-11-2020
+### Addd
+- main and partial placeholders seperated for client-async mode, now placeholder payload can be string or an object
 # [3.33.0] - 23-11-2020
 ### Fix
 - Fix for redirectionEnabled attribute to allow ssr redirection.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puzzle-js/core",
-  "version": "3.45.0",
+  "version": "3.46.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "logo": "https://image.ibb.co/jM29on/puzzlelogo.png",

--- a/src/fragment.ts
+++ b/src/fragment.ts
@@ -290,8 +290,14 @@ export class FragmentStorefront extends Fragment {
     })
       .then(res => res.text())
       .then(html => {
-        logger.info(`Received placeholder contents of fragment: ${this.name}`);
-        return html;
+        try{
+          const placeholderContent = JSON.parse(html);
+          logger.info(`Received placeholder contents: ${placeholderContent} of fragment: ${this.name}`);
+          return placeholderContent
+        }catch(e) {
+          logger.info(`Received placeholder contents of fragment: ${this.name} as string`);
+          return html
+        }
       })
       .catch(err => {
         logger.error(`Failed to fetch placeholder for fragment: ${this.fragmentUrl}/placeholder`, { error: err });

--- a/src/template.ts
+++ b/src/template.ts
@@ -656,7 +656,8 @@ export class Template {
 
           if (element.parentNode.name !== 'head') {
             if (fragment.clientAsync) {
-              this.dom(element).replaceWith(`<div id="${fragment.name}" puzzle-fragment="${element.attribs.name}" puzzle-gateway="${element.attribs.from}" ${element.attribs.partial ? 'fragment-partial="' + element.attribs.partial + '"' : ''}>${asyncPlaceholder}</div>`);
+              const placeholder = typeof asyncPlaceholder === 'object' ? asyncPlaceholder[partial] || "" : asyncPlaceholder;
+              this.dom(element).replaceWith(`<div id="${fragment.name}" puzzle-fragment="${element.attribs.name}" puzzle-gateway="${element.attribs.from}" ${element.attribs.partial ? 'fragment-partial="' + element.attribs.partial + '"' : ''}>${placeholder}</div>`);
             } else {
               this.dom(element).replaceWith(`<div id="${fragment.name}" puzzle-fragment="${element.attribs.name}" puzzle-gateway="${element.attribs.from}" ${element.attribs.partial ? 'fragment-partial="' + element.attribs.partial + '"' : ''}>${replaceKey}</div><script>PuzzleJs.emit('${EVENT.ON_FRAGMENT_RENDERED}','${fragment.name}');</script>`);
             }

--- a/tests/fragment.spec.ts
+++ b/tests/fragment.spec.ts
@@ -241,6 +241,19 @@ describe('Fragment', () => {
             expect(placeholder).to.eq(placeholderContent);
         });
 
+        it('should return placeholders for main and partials', async () => {
+            const placeholderContent = "{\"main\":\"<div>placeholder</div>\",\"partial-1\":\"<div>partial placeholder</div>\"}"
+            const scope = nock('http://local.gatewaysimulator.com')
+                .get('/product/placeholder')
+                .reply(200, placeholderContent);
+            const fragment = new FragmentStorefront('product', 'test');
+            fragment.update(commonFragmentConfig, 'http://local.gatewaysimulator.com', '');
+
+            const placeholder = await fragment.getPlaceholder();
+            expect(placeholder["partial-1"]).to.eq(JSON.parse(placeholderContent)["partial-1"]);
+            expect(placeholder["main"]).to.eq(JSON.parse(placeholderContent)["main"]);
+        });
+
         it('should return empty placeholder on any exception', async () => {
             const fragment = new FragmentStorefront('product', 'test');
             fragment.update(commonFragmentConfig, 'http://local.gatewaysimulator.com', '');


### PR DESCRIPTION
#### What's this PR do?
* - seperate main and partial placeholders for client-async mode, now gateways can return a string or an object in placeholder functions

