### PR TITLE
Add gateway and url information to the thrown asset manager error payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+# [3.50.1] - 13-09-2022
+### Changed
+- Added more info to the reject body of get asset method (asset manager).
+
 # [3.49.1] - 20-10-2021
 ### Added
 - Added a config for loading css assets of fragments asynchronously.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puzzle-js/core",
-  "version": "3.50.0",
+  "version": "3.50.1",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "logo": "https://image.ibb.co/jM29on/puzzlelogo.png",

--- a/src/asset-manager.ts
+++ b/src/asset-manager.ts
@@ -36,7 +36,7 @@ class AssetManager {
           resolve(data as string);
         } else {
           logger.error(`Failed to fetch asset from gateway: ${url}`);
-          reject({error, response});
+          reject({error, response, url, gateway});
         }
       });
     });

--- a/tests/asset-manager.spec.ts
+++ b/tests/asset-manager.spec.ts
@@ -1,0 +1,19 @@
+import {expect} from "chai";
+import {AssetManager} from "../src/asset-manager";
+import faker from "faker";
+
+describe('Asset Manager', () => {
+    beforeEach(() => {
+        AssetManager.init();
+    });
+
+    it('should reject when trying to get asset with invalid url', () => {
+        const invalidUrl = "{url}";
+        const exampleGateway = faker.random.word();
+
+        return AssetManager.getAsset(invalidUrl, exampleGateway).catch((err) => {
+            expect(err["url"]).to.be.eq(invalidUrl);
+            expect(err["gateway"]).to.be.eq(exampleGateway);
+        });
+    });
+});


### PR DESCRIPTION
#### What's this PR do?

* It adds gateway and URL information to the thrown asset manager error payload for easier debugging.

#### Where should the reviewer start?
* -
#### How should this be manually tested?
* 
#### Any background context you want to provide?
* This is a mandatory error, and it is not possible to debug it without the logger. Logger error does not log this one with the default configuration so it can be handy in those stiuations.
#### What are the relevant tickets?
* -
#### Screenshots (if appropriate)
* - 
<img width="707" alt="image" src="https://user-images.githubusercontent.com/46731483/189734144-fd1388e9-8c4a-49f7-b576-e895d0a98039.png">

