### PR TITLE
fragment name added to logs for fragment error config not found case

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puzzle-js/core",
-  "version": "3.50.1",
+  "version": "3.50.2",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "logo": "https://image.ibb.co/jM29on/puzzlelogo.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puzzle-js/core",
-  "version": "3.50.2",
+  "version": "3.50.3",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "logo": "https://image.ibb.co/jM29on/puzzlelogo.png",

--- a/src/fragment.ts
+++ b/src/fragment.ts
@@ -316,7 +316,7 @@ export class FragmentStorefront extends Fragment {
     logger.info(`Trying to get error page of fragment: ${this.name}`);
 
     if (!this.config || !this.config.render.error) {
-      logger.warn('Error page is not enabled for fragment');
+      logger.warn(`Error page is not enabled for fragment: ${this.name}`);
       return '';
     }
 


### PR DESCRIPTION
#### What's this PR do?
* Adding fragment name to log for fragments that have not error config.
* We can not detecting the fragment without this log. 