### PR TITLE
feat: update puzzle-lib version for intersection observer rootMargin

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "lint:ts:fix": "./node_modules/.bin/tslint -p ./tsconfig.json --fix"
   },
   "dependencies": {
-    "@puzzle-js/client-lib": "^1.6.6",
+    "@puzzle-js/client-lib": "^1.7.0",
     "@types/socket.io-client": "^1.4.32",
     "async": "^3.0.1",
     "cheerio": "^1.0.0-rc.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puzzle-js/core",
-  "version": "3.50.4",
+  "version": "3.51.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "logo": "https://image.ibb.co/jM29on/puzzlelogo.png",


### PR DESCRIPTION
#### What's this PR do?
this pr updates puzzle-lib version as 1.7.0  rootMargin can be passed to intersection observer as option, 
related puzzle-lib pr -> [pr](https://github.com/puzzle-js/puzzle-lib/pull/50)
