### PR TITLE
bugfix: add fragment model to response of fragment request

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puzzle-js/core",
-  "version": "3.52.1",
+  "version": "3.52.2",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "logo": "https://image.ibb.co/jM29on/puzzlelogo.png",

--- a/src/template.ts
+++ b/src/template.ts
@@ -418,7 +418,7 @@ export class Template {
       res.end();
       this.pageClass._onResponseEnd();
     } else {
-      res.send(waitedReplacement.template.replace('</body>', () => `<script>PuzzleJs.emit('${EVENT.ON_PAGE_LOAD}');</script></body>`));
+      res.send(waitedReplacement.template.replace('</body>', () => `${Object.values(this.onVariableEventScripts).join("")}<script>PuzzleJs.emit('${EVENT.ON_PAGE_LOAD}');</script></body>`));
       this.pageClass._onResponseEnd();
     }
   }


### PR DESCRIPTION
#### What's this PR do?
* This bug fix makes it possible to set the objects in the `$model` returned by the data method in `index.tsx` to the `window`.

#### How should this be manually tested?
* It can be checked that datalayer defined fragments set the object under the window.
