### PR TITLE
Improve if attribute and fragment discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+# [3.60.10] - 19-12-2022
+### Changed
+- Template dependencies recognition and structure refactor.
+- Improvements on the fragment if attribute
+
 # [3.52.0] - 22-11-2022
 ### Changed
 - Removed ON_FRAGMENT_RENDER config due to unused and performance issues. After this changes, puzzle-lib will be imported end of the body and do not block the main thread. *Please be careful ON_FRAGMENT_RENDER is not used in gateway configs when update PuzzleJs to this version.*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@puzzle-js/core",
-  "version": "3.50.4",
+  "version": "3.60.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -388,9 +388,9 @@
       }
     },
     "@puzzle-js/client-lib": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@puzzle-js/client-lib/-/client-lib-1.6.6.tgz",
-      "integrity": "sha512-lsFawh18ke+6nYBOi3QYzkLWkbXnP1bgtxZPAf9VJsIbA5B632fdS64nBjiQ2xhaye+ZvC7/SWphGf8oxQSNLQ=="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@puzzle-js/client-lib/-/client-lib-1.8.0.tgz",
+      "integrity": "sha512-Oef+zwI60Lbqp7RRFW9A6AIZYK5dUU8coKLqpkL5EqMpjXg8YnbUfTa2EzTeCUqLF4KaPlAT0bk/t5+JzXmOqQ=="
     },
     "@sinonjs/commons": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puzzle-js/core",
-  "version": "3.52.2",
+  "version": "3.60.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "logo": "https://image.ibb.co/jM29on/puzzlelogo.png",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "lint:ts:fix": "./node_modules/.bin/tslint -p ./tsconfig.json --fix"
   },
   "dependencies": {
-    "@puzzle-js/client-lib": "^1.7.1",
+    "@puzzle-js/client-lib": "^1.8.0",
     "@types/socket.io-client": "^1.4.32",
     "async": "^3.0.1",
     "cheerio": "^1.0.0-rc.2",

--- a/src/template.ts
+++ b/src/template.ts
@@ -160,7 +160,7 @@ export class Template {
     logger.info(`[Compiling Page ${this.name}]`, 'Creating virtual dom');
     this.load();
 
-    if (this.fragments.length === 0) {
+    if (!this.fragments || this.fragments.length === 0) {
       logger.info(`[Compiling Page ${this.name}]`, 'No fragments detected, implementing single flush handler');
       this.replaceEmptyTags();
       const singleFlushHandlerWithoutFragments = TemplateCompiler.compile(Template.clearHtmlContent(this.dom.html()));

--- a/src/template.ts
+++ b/src/template.ts
@@ -38,7 +38,7 @@ interface CompressionStreamResponse extends express.Response {
 
 export class Template {
   dom: any;
-  fragments: { [name: string]: FragmentStorefront } = {};
+  fragments: FragmentStorefront[];
   pageClass: TemplateClass = new TemplateClass();
   private resourceInjector: ResourceInjector;
   private fragmentSentryConfiguration?: Record<string, FragmentSentryConfig>;
@@ -71,73 +71,81 @@ export class Template {
    */
   @benchmark(isDebug(), logger.info)
   getDependencies() {
+    const gateways: { [name: string]: { fragments: { [name: string]: FragmentStorefront } } } = {};
     let primaryName: string | null;
 
-    return this.dom(TEMPLATE_FRAGMENT_TAG_NAME).toArray().reduce((dependencyList: IPageDependentGateways, fragment: CheerioElement) => {
-      if (!dependencyList.gateways[fragment.attribs.from]) {
-        dependencyList.gateways[fragment.attribs.from] = {
+    const dependencies = this.dom(TEMPLATE_FRAGMENT_TAG_NAME).toArray().reduce((dependencyList: IPageDependentGateways, fragment: CheerioElement) => {
+      const { from, name: fragmentName } = fragment.attribs;
+      if (!dependencyList.gateways[from]) {
+        gateways[from] = { fragments: {} };
+        dependencyList.gateways[from] = {
           gateway: null,
-          ready: false
+          ready: false,
+          fragments: {}
         };
       }
 
-      if (!dependencyList.fragments[fragment.attribs.name]) {
-        this.fragments[fragment.attribs.name] = new FragmentStorefront(fragment.attribs.name, fragment.attribs.from, { ...fragment.attribs });
-        dependencyList.fragments[fragment.attribs.name] = {
-          gateway: fragment.attribs.from,
-          instance: this.fragments[fragment.attribs.name]
+      if (!dependencyList.gateways[from].fragments[fragmentName]) {
+        gateways[from].fragments[fragmentName] = new FragmentStorefront(fragmentName, from, { ...fragment.attribs });
+        dependencyList.gateways[from].fragments[fragmentName] = {
+          gateway: from,
+          instance: gateways[from].fragments[fragmentName]
         };
       }
 
-      if (this.fragmentSentryConfiguration && typeof this.fragmentSentryConfiguration[fragment.attribs.name] !== "undefined") {
-        const fragmentName = fragment.attribs.name;
+      if (this.fragmentSentryConfiguration && typeof this.fragmentSentryConfiguration[fragmentName] !== "undefined") {
         const fragmentType = this.fragmentSentryConfiguration[fragmentName];
 
         if (fragmentType === FragmentSentryConfig.CLIENT_ASYNC) {
-          this.fragments[fragment.attribs.name].attributes = Object.assign(this.fragments[fragment.attribs.name].attributes, fragment.attribs);
-          this.fragments[fragment.attribs.name].primary = false;
-          this.fragments[fragment.attribs.name].shouldWait = true;
-          this.fragments[fragment.attribs.name].clientAsync = true;
+          gateways[from].fragments[fragmentName].attributes = Object.assign(gateways[from].fragments[fragmentName].attributes, fragment.attribs);
+          gateways[from].fragments[fragmentName].primary = false;
+          gateways[from].fragments[fragmentName].shouldWait = true;
+          gateways[from].fragments[fragmentName].clientAsync = true;
         } else if (fragmentType === FragmentSentryConfig.WAITED || (fragment.parent && fragment.parent.name === 'head')) {
-          this.fragments[fragment.attribs.name].shouldWait = true;
+          gateways[from].fragments[fragmentName].shouldWait = true;
         } else if (fragmentType === FragmentSentryConfig.PRIMARY && primaryName === null) {
           primaryName = fragment.attribs.name;
-          this.fragments[fragment.attribs.name].primary = true;
-          this.fragments[fragment.attribs.name].shouldWait = true;
+          gateways[from].fragments[fragmentName].primary = true;
+          gateways[from].fragments[fragmentName].shouldWait = true;
         } else if (fragmentType === FragmentSentryConfig.STATIC) {
-          this.fragments[fragment.attribs.name].static = true;
+          gateways[from].fragments[fragmentName].static = true;
         }
       } else {
-        if (!this.fragments[fragment.attribs.name].primary) {
+        if (!gateways[from].fragments[fragmentName].primary) {
           if (typeof fragment.attribs.primary !== 'undefined') {
             if (primaryName != null && primaryName !== fragment.attribs.name) throw new PuzzleError(ERROR_CODES.MULTIPLE_PRIMARY_FRAGMENTS);
             primaryName = fragment.attribs.name;
-            this.fragments[fragment.attribs.name].primary = true;
-            this.fragments[fragment.attribs.name].shouldWait = true;
+            gateways[from].fragments[fragmentName].primary = true;
+            gateways[from].fragments[fragmentName].shouldWait = true;
           }
         }
 
-        if (!this.fragments[fragment.attribs.name].shouldWait) {
-          this.fragments[fragment.attribs.name].shouldWait = typeof fragment.attribs.shouldwait !== 'undefined' || (fragment.parent && fragment.parent.name === 'head') || false;
+        if (!gateways[from].fragments[fragmentName].shouldWait) {
+          gateways[from].fragments[fragmentName].shouldWait = typeof fragment.attribs.shouldwait !== 'undefined' || (fragment.parent && fragment.parent.name === 'head') || false;
         }
 
-        if (this.fragments[fragment.attribs.name].clientAsync || (typeof fragment.attribs['client-async'] !== "undefined" || typeof fragment.attribs['async-c2'] !== "undefined")) {
-          this.fragments[fragment.attribs.name].attributes = Object.assign(this.fragments[fragment.attribs.name].attributes, fragment.attribs);
-          this.fragments[fragment.attribs.name].primary = false;
-          this.fragments[fragment.attribs.name].shouldWait = true;
-          this.fragments[fragment.attribs.name].clientAsync = true;
-          this.fragments[fragment.attribs.name].clientAsyncForce = this.fragments[fragment.attribs.name].clientAsyncForce || typeof fragment.attribs['client-async-force'] !== "undefined";
-          this.fragments[fragment.attribs.name].criticalCss = this.fragments[fragment.attribs.name].criticalCss || typeof fragment.attribs['critical-css'] !== "undefined";
-          this.fragments[fragment.attribs.name].onDemand = this.fragments[fragment.attribs.name].onDemand || typeof fragment.attribs['on-demand'] !== "undefined";
-          this.fragments[fragment.attribs.name].asyncDecentralized = this.fragments[fragment.attribs.name].asyncDecentralized || typeof fragment.attribs['async-c2'] !== "undefined";
+        if (gateways[from].fragments[fragmentName].clientAsync || (typeof fragment.attribs['client-async'] !== "undefined" || typeof fragment.attribs['async-c2'] !== "undefined")) {
+          gateways[from].fragments[fragmentName].attributes = Object.assign(gateways[from].fragments[fragmentName].attributes, fragment.attribs);
+          gateways[from].fragments[fragmentName].primary = false;
+          gateways[from].fragments[fragmentName].shouldWait = true;
+          gateways[from].fragments[fragmentName].clientAsync = true;
+          gateways[from].fragments[fragmentName].clientAsyncForce = gateways[from].fragments[fragmentName].clientAsyncForce || typeof fragment.attribs['client-async-force'] !== "undefined";
+          gateways[from].fragments[fragmentName].criticalCss = gateways[from].fragments[fragmentName].criticalCss || typeof fragment.attribs['critical-css'] !== "undefined";
+          gateways[from].fragments[fragmentName].onDemand = gateways[from].fragments[fragmentName].onDemand || typeof fragment.attribs['on-demand'] !== "undefined";
+          gateways[from].fragments[fragmentName].asyncDecentralized = gateways[from].fragments[fragmentName].asyncDecentralized || typeof fragment.attribs['async-c2'] !== "undefined";
         }
       }
 
       return dependencyList;
     }, {
-      gateways: {},
-      fragments: {}
+      gateways: {}
     });
+
+    this.fragments = Object.values(gateways)
+        .map(gw => Object.values(gw.fragments))
+        .reduce((acc, val) => [ ...acc, ...val ], []);
+
+    return dependencies;
   }
 
   //todo fragmentConfigleri versiyon bilgileriyle inmis olmali ki assetleri versionlara gore compile edebilelim. ayni not gatewayde de var.
@@ -151,42 +159,44 @@ export class Template {
   async compile(testCookies: ICookieMap, isDebug = false, precompile = false): Promise<IFragmentEndpointHandler> {
     logger.info(`[Compiling Page ${this.name}]`, 'Creating virtual dom');
     this.load();
-    
-    if (Object.keys(this.fragments).length === 0) {
+
+    if (this.fragments.length === 0) {
       logger.info(`[Compiling Page ${this.name}]`, 'No fragments detected, implementing single flush handler');
       this.replaceEmptyTags();
       const singleFlushHandlerWithoutFragments = TemplateCompiler.compile(Template.clearHtmlContent(this.dom.html()));
       return this.buildHandler(singleFlushHandlerWithoutFragments, [], [], [], isDebug);
     }
-    
+
     if (this.intersectionObserverOptions) {
       this.resourceInjector = new ResourceInjector(this.fragments, this.name, testCookies, this.intersectionObserverOptions);
     } else {
       this.resourceInjector = new ResourceInjector(this.fragments, this.name, testCookies);
     }
-    
+
     logger.info('resource injector instance created');
 
-    Object.values(this.fragments).forEach(fragment => {
+    this.fragments.forEach(fragment => {
       if (fragment.config) {
         fragment.static = fragment.config.render.static = fragment.config.render.static || fragment.static;
       }
     });
 
-    const chunkedFragmentsWithShouldWait = Object.values(this.fragments).filter(fragment => fragment.config && fragment.shouldWait && !fragment.config.render.static);
-    const chunkedFragmentsWithoutWait = Object.values(this.fragments).filter(fragment => fragment.config && !fragment.shouldWait && !fragment.config.render.static);
-    const staticFragments = Object.values(this.fragments).filter(fragment => fragment.config && fragment.config.render.static);
+    const chunkedFragmentsWithShouldWait = this.fragments.filter(fragment => fragment.config && fragment.shouldWait && !fragment.config.render.static);
+    const chunkedFragmentsWithoutWait = this.fragments.filter(fragment => fragment.config && !fragment.shouldWait && !fragment.config.render.static);
+    const staticFragments = this.fragments.filter(fragment => fragment.config && fragment.config.render.static);
 
     logger.info(`[Compiling Page ${this.name}]`, 'Injecting Puzzle Lib to head');
     this.resourceInjector.injectAssets(this.dom);
     this.resourceInjector.injectDependencies(this.dom);
     this.resourceInjector.injectLibraryConfig(this.dom, isDebug);
 
-    const pageDecentrealized = Object.values(this.fragments).some(fragment => fragment.asyncDecentralized);
+    const pageDecentrealized = this.fragments.some(fragment => fragment.asyncDecentralized);
 
     if(pageDecentrealized){
       this.dom('head').prepend(`<script src="${GUN_PATH}"> </script>`);
     }
+
+    this.wrapConditionalFragmentContainers(this.fragments);
 
     // replace meta async
     for(let i = 0,len = chunkedFragmentsWithShouldWait.length;i < len;i++){
@@ -197,7 +207,7 @@ export class Template {
               });
           }
       }
-    
+
     // todo kaldir lib bagla
     const replaceScripts: any[] = [];
 
@@ -207,7 +217,7 @@ export class Template {
     logger.info(`[Compiling Page ${this.name}]`, 'Adding containers for chunked fragments');
     const chunkReplacements: IReplaceSet[] = this.replaceChunkedFragmentContainers(chunkedFragmentsWithoutWait);
 
-    this.replaceUnfetchedFragments(Object.values(this.fragments).filter(fragment => !fragment.config));
+    this.replaceUnfetchedFragments(this.fragments.filter(fragment => !fragment.config));
 
     // todo kaldir lib bag
     //await this.addDependencies();
@@ -319,8 +329,6 @@ export class Template {
     let statusCode = HTTP_STATUS_CODE.OK;
     let headers = {};
     let cookies = {};
-    
-
 
     await Promise.all(waitedFragments.map(async waitedFragmentReplacement => {
       const attributes = TemplateCompiler.processExpression(waitedFragmentReplacement.fragmentAttributes, this.pageClass, req);
@@ -343,13 +351,13 @@ export class Template {
           }else{
             statusCode = fragmentContent.status;
           }
-          
+
           headers = {
             ...headers,
             ...fragmentContent.headers
           };
         }
-        cookies = fragmentContent.cookies; 
+        cookies = fragmentContent.cookies;
       } else if (waitedFragmentReplacement.fragmentAttributes && waitedFragmentReplacement.fragmentAttributes.enableRedirect) {
         if ((fragmentContent.status === HTTP_STATUS_CODE.MOVED_PERMANENTLY || fragmentContent.status === HTTP_STATUS_CODE.MOVED_TEMPORARILY) && (statusCode === 200 || statusCode === 404)) {
           statusCode = fragmentContent.status;
@@ -555,6 +563,25 @@ export class Template {
   private replaceUnfetchedFragments(fragments: FragmentStorefront[]) {
     fragments.forEach(fragment => {
       this.dom(`fragment[from="${fragment.from}"][name="${fragment.name}"]`).replaceWith(`<div puzzle-fragment="${fragment.name}" puzzle-gateway="${fragment.from}">${CONTENT_NOT_FOUND_ERROR}</div>`);
+    });
+  }
+
+  /**
+   * Find fragments with if attributes and wraps them with expression.
+   * @param {FragmentStorefront[]} fragments
+   * @returns {void}
+   */
+  @benchmark(isDebug(), logger.info)
+  private wrapConditionalFragmentContainers(fragments: FragmentStorefront[]) {
+    fragments.forEach(fragment => {
+      this.dom(`fragment[from="${fragment.from}"][name="${fragment.name}"]`)
+        .each((i, element) => {
+          const ifAttr = fragment.attributes.if;
+          const condition = ifAttr && (TemplateCompiler.isExpression(ifAttr) ? (ifAttr.match(TemplateCompiler.EXPRESSION_REGEX) || [])[1] : ifAttr);
+          if (condition) {
+            this.dom(element).replaceWith(`\${if(${condition}){}${this.dom(element)}\${}}`);
+          }
+        });
     });
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -204,14 +204,14 @@ export interface IPageDependentGateways {
     gateways: {
         [name: string]: {
             gateway: GatewayStorefrontInstance | null,
-            ready: boolean
-        }
-    };
-    fragments: {
-        [name: string]: {
-            instance: FragmentStorefront,
-            gateway: string
-        }
+            ready: boolean,
+            fragments: {
+                [name: string]: {
+                    instance: FragmentStorefront,
+                    gateway: string
+                }
+            };
+        },
     };
 }
 

--- a/tests/page.spec.ts
+++ b/tests/page.spec.ts
@@ -40,69 +40,69 @@ describe('Page', () => {
     const newPage = new Page(template, {}, '');
 
     expect(newPage.gatewayDependencies).to.deep.include({
-      fragments: {
-        header: {
-          gateway: 'Browsing',
-          instance: {
-            "_attributes": {
-              "from": "Browsing",
-              "name": "header",
-            },
-            name: 'header',
-            clientAsync: false,
-            clientAsyncForce: false,
-            asyncDecentralized: false,
-            criticalCss: false,
-            onDemand: false,
-            primary: false,
-            shouldWait: false,
-            from: "Browsing",
-            static: false
-          }
-        },
-        content: {
-          gateway: 'Browsing',
-          instance: {
-            "_attributes": {
-              "from": "Browsing",
-              "name": "content",
-            },
-            name: 'content',
-            primary: false,
-            clientAsync: false,
-            clientAsyncForce: false,
-            asyncDecentralized: false,
-            criticalCss: false,
-            onDemand: false,
-            shouldWait: false,
-            from: "Browsing",
-            static: false
-          }
-        },
-        footer: {
-          gateway: 'Browsing',
-          instance: {
-            "_attributes": {
-              "from": "Browsing",
-              "name": "footer",
-            },
-            name: 'footer',
-            primary: false,
-            clientAsync: false,
-            clientAsyncForce: false,
-            asyncDecentralized: false,
-            criticalCss: false,
-            onDemand: false,
-            shouldWait: false,
-            from: "Browsing",
-            static: false
-          }
-        }
-      },
       gateways: {
         Browsing: {
           gateway: null,
-          ready: false
+          ready: false,
+          fragments: {
+            header: {
+              gateway: 'Browsing',
+              instance: {
+                "_attributes": {
+                  "from": "Browsing",
+                  "name": "header",
+                },
+                name: 'header',
+                clientAsync: false,
+                clientAsyncForce: false,
+                asyncDecentralized: false,
+                criticalCss: false,
+                onDemand: false,
+                primary: false,
+                shouldWait: false,
+                from: "Browsing",
+                static: false
+              }
+            },
+            content: {
+              gateway: 'Browsing',
+              instance: {
+                "_attributes": {
+                  "from": "Browsing",
+                  "name": "content",
+                },
+                name: 'content',
+                primary: false,
+                clientAsync: false,
+                clientAsyncForce: false,
+                asyncDecentralized: false,
+                criticalCss: false,
+                onDemand: false,
+                shouldWait: false,
+                from: "Browsing",
+                static: false
+              }
+            },
+            footer: {
+              gateway: 'Browsing',
+              instance: {
+                "_attributes": {
+                  "from": "Browsing",
+                  "name": "footer",
+                },
+                name: 'footer',
+                primary: false,
+                clientAsync: false,
+                clientAsyncForce: false,
+                asyncDecentralized: false,
+                criticalCss: false,
+                onDemand: false,
+                shouldWait: false,
+                from: "Browsing",
+                static: false
+              }
+            }
+          }
         }
       }
     });
@@ -290,8 +290,9 @@ describe('Page', () => {
     gateway.events.on(EVENTS.GATEWAY_UPDATED, () => {
       if (gateway.config) {
         expect(gateway.config.fragments.header.testCookie).to.eq('zek');
-        if (newPage.gatewayDependencies.fragments.header.instance.config) {
-          expect(newPage.gatewayDependencies.fragments.header.instance.config.testCookie).to.eq('zek');
+        const fragmentConfig = newPage.fragments.find(f => f.instance.name === "header")!.instance!.config;
+        if (fragmentConfig) {
+          expect(fragmentConfig.testCookie).to.eq('zek');
           done();
         } else {
           done('config does not exists on istance');

--- a/tests/resource-injector.spec.ts
+++ b/tests/resource-injector.spec.ts
@@ -38,7 +38,7 @@ describe('Resource Injector', () => {
 
         // assert
         expect(dom("body").children().length).toBe(assets.length);
-        
+
         assets.forEach( (asset) => {
             const script = dom("body").children(`script[puzzle-dependency=${asset.name}]`);
             if(script.length <= 1) {
@@ -137,28 +137,27 @@ describe('Resource Injector', () => {
     it("should inject library config with intersection observer opts", () => {
 
         // arrange
-        const fragments = {
-            "f1":  FragmentHelper.create(),
-            "f2":  FragmentHelper.create()
-        };
+        const fragments = [
+            FragmentHelper.create(),
+            FragmentHelper.create()
+        ];
 
         const intersectionObserverOptions: IntersectionObserverInit = {
             rootMargin: "500px",
-        }
+        };
 
-        const fragmentList = Object.keys(fragments).map( (fKey) => fragments[fKey] );
         let assets: any = [];
-        fragmentList.forEach((fragment) => { assets = assets.concat(fragment.config.assets.map(asset => ({
+        fragments.forEach((fragment) => { assets = assets.concat(fragment.config.assets.map(asset => ({
             ...asset,
             fragment: fragment.name
         })))});
         const pageName = faker.random.word();
         const expectedConfig = {
             page: pageName,
-            fragments: fragmentList.map((fragment) => ({ "name": fragment.name, attributes: fragment.attributes, "chunked": (fragment.config ? (fragment.shouldWait || (fragment.config.render.static || false)) : false) })),
+            fragments: fragments.map((fragment) => ({ "name": fragment.name, attributes: fragment.attributes, "chunked": (fragment.config ? (fragment.shouldWait || (fragment.config.render.static || false)) : false) })),
             assets: assets.filter((asset) => asset.type === RESOURCE_TYPE.JS),
             dependencies: [],
-            intersectionObserverOptions: intersectionObserverOptions,
+            intersectionObserverOptions,
             peers: []
         };
         expectedConfig.assets.forEach((asset) => { asset.preLoaded = false });
@@ -374,7 +373,7 @@ describe('Resource Injector', () => {
 
         // assert
         const depScript = dom("body").children(`script[puzzle-dependency=${depName}]`);
-        
+
         expect(depScript.attr().src).toBe(dep.link);
         expect(depScript.attr()["puzzle-dependency"]).toBe(dep.name);
     });
@@ -383,13 +382,13 @@ describe('Resource Injector', () => {
     it("should inject dependencies if load method is not ON_RENDER_START", () => {
 
         // arrange
-        const fragments = {
-            "f1": FragmentHelper.create()
-        };
+        const fragments = [
+            FragmentHelper.create()
+        ];
         const depName = faker.lorem.word();
-        const dep = fragments.f1.config.dependencies[0];
-        fragments.f1.config.assets[0].type = RESOURCE_TYPE.JS;
-        fragments.f1.config.assets[0].dependent = [depName];
+        const dep = fragments[0].config.dependencies[0];
+        fragments[0].config.assets[0].type = RESOURCE_TYPE.JS;
+        fragments[0].config.assets[0].dependent = [depName];
         dep.name = depName;
         dep.type = RESOURCE_TYPE.JS;
         dep.loadMethod = RESOURCE_LOADING_TYPE.ON_PAGE_RENDER;

--- a/tests/resource-injector.spec.ts
+++ b/tests/resource-injector.spec.ts
@@ -21,13 +21,12 @@ describe('Resource Injector', () => {
     it("should inject assets using default version", () => {
 
         // arrange
-        const fragments = {
-            "f1": FragmentHelper.create(),
-            "f2": FragmentHelper.create()
-        };
-        const fragmentList = Object.keys(fragments).map( (fKey) => fragments[fKey] );
+        const fragments = [
+            FragmentHelper.create(),
+            FragmentHelper.create()
+        ];
         let assets: any = [];
-        fragmentList.forEach((fragment) => { assets = assets.concat(fragment.config.assets)});
+        fragments.forEach((fragment) => { assets = assets.concat(fragment.config.assets); });
 
 
         // act
@@ -52,22 +51,22 @@ describe('Resource Injector', () => {
     it("should inject assets using passive version", () => {
 
         // arrange
-        const fragments = {
-            "f1": FragmentHelper.create(),
-            "f2": FragmentHelper.create()
-        };
+        const fragments = [
+            FragmentHelper.create(),
+            FragmentHelper.create()
+        ];
         const f1Version = faker.random.arrayElement(["2.0.0", "3.0.0"]);
         const f2Version = faker.random.arrayElement(["2.0.0", "3.0.0"]);
-        sandbox.stub(fragments.f1, "detectVersion").callsFake(() => f1Version);
-        sandbox.stub(fragments.f2, "detectVersion").callsFake(() => f2Version);
+        sandbox.stub(fragments[0], "detectVersion").callsFake(() => f1Version);
+        sandbox.stub(fragments[1], "detectVersion").callsFake(() => f2Version);
 
         // act
         const dom = cheerio.load("<html><head></head><body></body></html>");
         const resourceInjector = new ResourceInjector(fragments, "", {});
         resourceInjector.injectAssets(dom as any);
 
-        const assets1 = fragments.f1.config.passiveVersions[f1Version].assets.filter((asset) => asset.type === RESOURCE_TYPE.JS);
-        const assets2 = fragments.f2.config.passiveVersions[f2Version].assets.filter((asset) => asset.type === RESOURCE_TYPE.JS);
+        const assets1 = fragments[0].config.passiveVersions[f1Version].assets.filter((asset) => asset.type === RESOURCE_TYPE.JS);
+        const assets2 = fragments[1].config.passiveVersions[f2Version].assets.filter((asset) => asset.type === RESOURCE_TYPE.JS);
 
         // assert
         expect(dom("body").children().length).toBe(assets1.length + assets2.length);
@@ -83,13 +82,12 @@ describe('Resource Injector', () => {
     it("should not inject assets if load method is not ON_RENDER_START", () => {
 
         // arrange
-        const fragments = {
-            "f1": FragmentHelper.create(),
-            "f2": FragmentHelper.create()
-        };
-        const fragmentList = Object.keys(fragments).map( (fKey) => fragments[fKey] );
+        const fragments = [
+            FragmentHelper.create(),
+            FragmentHelper.create()
+        ];
         let assets: any = [];
-        fragmentList.forEach((fragment) => { assets = assets.concat(fragment.config.assets)});
+        fragments.forEach((fragment) => { assets = assets.concat(fragment.config.assets); });
         assets.forEach((asset)=> { asset.loadMethod = 1; });
 
         // act
@@ -105,20 +103,19 @@ describe('Resource Injector', () => {
     it("should inject library config", () => {
 
         // arrange
-        const fragments = {
-            "f1":  FragmentHelper.create(),
-            "f2":  FragmentHelper.create()
-        };
-        const fragmentList = Object.keys(fragments).map( (fKey) => fragments[fKey] );
+        const fragments = [
+            FragmentHelper.create(),
+            FragmentHelper.create()
+        ];
         let assets: any = [];
-        fragmentList.forEach((fragment) => { assets = assets.concat(fragment.config.assets.map(asset => ({
+        fragments.forEach((fragment) => { assets = assets.concat(fragment.config.assets.map(asset => ({
             ...asset,
             fragment: fragment.name
-        })))});
+        })));});
         const pageName = faker.random.word();
         const expectedConfig = {
             page: pageName,
-            fragments: fragmentList.map((fragment) => ({ "name": fragment.name, attributes: fragment.attributes, "chunked": (fragment.config ? (fragment.shouldWait || (fragment.config.render.static || false)) : false) })),
+            fragments: fragments.map((fragment) => ({ "name": fragment.name, attributes: fragment.attributes, "chunked": (fragment.config ? (fragment.shouldWait || (fragment.config.render.static || false)) : false) })),
             assets: assets.filter((asset) => asset.type === RESOURCE_TYPE.JS),
             dependencies: [],
             peers: []
@@ -181,16 +178,16 @@ describe('Resource Injector', () => {
     it("should inject style sheets using default version", async (done) => {
 
         // arrange
-        const fragments = {
-            "f1": FragmentHelper.create(),
-            "f2": FragmentHelper.create()
-        };
+        const fragments = [
+            FragmentHelper.create(),
+            FragmentHelper.create()
+        ];
 
-        sandbox.stub(fragments.f1, "getAsset").callsFake((arg) => arg + "-CSS-");
-        sandbox.stub(fragments.f2, "getAsset").callsFake((arg) => arg + "-CSS-");
+        sandbox.stub(fragments[0], "getAsset").callsFake((arg) => arg + "-CSS-");
+        sandbox.stub(fragments[1], "getAsset").callsFake((arg) => arg + "-CSS-");
         sandbox.stub(ResourceFactory.instance, "getRawContent").callsFake( (arg): any => arg + "-CSS-");
         sandbox.stub(CleanCSS.prototype, "minify").callsFake((arg): any => ({ styles: arg }));
-        fragments.f1.config.dependencies.push({
+        fragments[0].config.dependencies.push({
             name: faker.lorem.word().split(' ')[0],
             type: faker.random.arrayElement([RESOURCE_TYPE.JS, RESOURCE_TYPE.CSS]),
             content: faker.lorem.word()
@@ -201,8 +198,8 @@ describe('Resource Injector', () => {
         const resourceInjector = new ResourceInjector(fragments, "", {});
         await resourceInjector.injectStyleSheets(dom as any, false);
 
-        const c1 = fragments.f1.config;
-        const c2 = fragments.f2.config;
+        const c1 = fragments[0].config;
+        const c2 = fragments[1].config;
 
         const assets = c1.assets.concat(c2.assets).filter((asset) => asset.type === RESOURCE_TYPE.CSS);
         const deps = c1.dependencies.concat(c2.dependencies).filter((dep) => dep.type === RESOURCE_TYPE.CSS);
@@ -222,17 +219,17 @@ describe('Resource Injector', () => {
     it("should inject style sheets using passive version", async (done) => {
 
         // arrange
-        const fragments = {
-            "f1": FragmentHelper.create(),
-            "f2": FragmentHelper.create()
-        };
+        const fragments = [
+            FragmentHelper.create(),
+            FragmentHelper.create()
+        ];
 
         const f1Version = faker.random.arrayElement(["2.0.0", "3.0.0"]);
         const f2Version = faker.random.arrayElement(["2.0.0", "3.0.0"]);
-        sandbox.stub(fragments.f1, "detectVersion").callsFake(() => f1Version);
-        sandbox.stub(fragments.f2, "detectVersion").callsFake( () => f2Version);
-        sandbox.stub(fragments.f1, "getAsset").callsFake((arg) => arg + "-CSS-");
-        sandbox.stub(fragments.f2, "getAsset").callsFake((arg) => arg + "-CSS-");
+        sandbox.stub(fragments[0], "detectVersion").callsFake(() => f1Version);
+        sandbox.stub(fragments[1], "detectVersion").callsFake( () => f2Version);
+        sandbox.stub(fragments[0], "getAsset").callsFake((arg) => arg + "-CSS-");
+        sandbox.stub(fragments[1], "getAsset").callsFake((arg) => arg + "-CSS-");
         sandbox.stub(ResourceFactory.instance, "getRawContent").callsFake( (arg): any => arg + "-CSS-");
         sandbox.stub(CleanCSS.prototype, "minify").callsFake( (arg): any => ({ styles: arg }));
 
@@ -241,8 +238,8 @@ describe('Resource Injector', () => {
         const resourceInjector = new ResourceInjector(fragments, "", {});
         await resourceInjector.injectStyleSheets(dom as any, false);
 
-        const c1 = fragments.f1.config.passiveVersions[f1Version];
-        const c2 = fragments.f2.config.passiveVersions[f2Version];
+        const c1 = fragments[0].config.passiveVersions[f1Version];
+        const c2 = fragments[1].config.passiveVersions[f2Version];
 
         const assets = c1.assets.concat(c2.assets).filter((asset) => asset.type === RESOURCE_TYPE.CSS);
         const deps = c1.dependencies.concat(c2.dependencies).filter((dep) => dep.type === RESOURCE_TYPE.CSS);
@@ -260,10 +257,10 @@ describe('Resource Injector', () => {
 
     it("should inject external style sheets dependecies as async", async (done) => {
         // arrange
-        const fragments = {
-            "f1": FragmentHelper.create(),
-            "f2": FragmentHelper.create()
-        };
+        const fragments = [
+            FragmentHelper.create(),
+            FragmentHelper.create()
+        ];
         const dependency = {
             name: faker.lorem.word().split(' ')[0],
             type: RESOURCE_TYPE.CSS,
@@ -271,10 +268,10 @@ describe('Resource Injector', () => {
             executeType: RESOURCE_CSS_EXECUTE_TYPE.ASYNC
         };
 
-        sandbox.stub(fragments.f1, "getAsset").callsFake((arg) => arg + "-CSS-");
-        sandbox.stub(fragments.f2, "getAsset").callsFake((arg) => arg + "-CSS-");
+        sandbox.stub(fragments[0], "getAsset").callsFake((arg) => arg + "-CSS-");
+        sandbox.stub(fragments[1], "getAsset").callsFake((arg) => arg + "-CSS-");
         sandbox.stub(ResourceFactory.instance, "get").callsFake( (arg): any => dependency);
-        fragments.f1.config.dependencies.push(dependency);
+        fragments[0].config.dependencies.push(dependency);
 
         // act
         const dom = cheerio.load("<html><head></head><body></body></html>");
@@ -288,20 +285,20 @@ describe('Resource Injector', () => {
 
     it("should inject external style sheets dependecies as sync", async (done) => {
         // arrange
-        const fragments = {
-            "f1": FragmentHelper.create(),
-            "f2": FragmentHelper.create()
-        };
+        const fragments = [
+            FragmentHelper.create(),
+            FragmentHelper.create()
+        ];
         const dependency = {
             name: faker.lorem.word().split(' ')[0],
             type: RESOURCE_TYPE.CSS,
             content: faker.lorem.word()
         };
 
-        sandbox.stub(fragments.f1, "getAsset").callsFake((arg) => arg + "-CSS-");
-        sandbox.stub(fragments.f2, "getAsset").callsFake((arg) => arg + "-CSS-");
+        sandbox.stub(fragments[0], "getAsset").callsFake((arg) => arg + "-CSS-");
+        sandbox.stub(fragments[1], "getAsset").callsFake((arg) => arg + "-CSS-");
         sandbox.stub(ResourceFactory.instance, "get").callsFake( (arg): any => dependency);
-        fragments.f1.config.dependencies.push(dependency);
+        fragments[0].config.dependencies.push(dependency);
 
         // act
         const dom = cheerio.load("<html><head></head><body></body></html>");
@@ -315,11 +312,11 @@ describe('Resource Injector', () => {
 
     it("should inject external style sheets assets as async if it is enabled", async (done) => {
         // arrange
-        const fragments = {
-            "f1": FragmentHelper.create()
-        };
+        const fragments = [
+            FragmentHelper.create()
+        ];
 
-        sandbox.stub(fragments.f1, "getAsset").callsFake((arg) => arg + "-CSS-");
+        sandbox.stub(fragments[0], "getAsset").callsFake((arg) => arg + "-CSS-");
 
         // act
         const dom = cheerio.load("<html><head></head><body></body></html>");
@@ -327,18 +324,18 @@ describe('Resource Injector', () => {
         await resourceInjector.injectStyleSheets(dom as any, false, true, true);
 
         // assert
-        expect(dom("head").find("noscript").length).toEqual(fragments.f1.config.assets.filter(asset => asset.type === RESOURCE_TYPE.CSS).length);
+        expect(dom("head").find("noscript").length).toEqual(fragments[0].config.assets.filter(asset => asset.type === RESOURCE_TYPE.CSS).length);
         done();
     });
 
     it("should inject error message if asset invalid", () => {
 
         // arrange
-        const fragments = {
-            "f1": FragmentHelper.create()
-        };
+        const fragments = [
+            FragmentHelper.create()
+        ];
         const assetName = faker.lorem.word();
-        fragments.f1.config.assets = [ {
+        fragments[0].config.assets = [ {
             name: assetName,
             type: RESOURCE_TYPE.JS,
             loadMethod: RESOURCE_LOADING_TYPE.ON_RENDER_START
@@ -358,13 +355,13 @@ describe('Resource Injector', () => {
     it("should inject dependencies if load method is ON_RENDER_START", () => {
 
         // arrange
-        const fragments = {
-            "f1": FragmentHelper.create()
-        };
+        const fragments = [
+            FragmentHelper.create()
+        ];
         const depName = faker.lorem.word();
-        const dep = fragments.f1.config.dependencies[0];
-        fragments.f1.config.assets[0].type = RESOURCE_TYPE.JS;
-        fragments.f1.config.assets[0].dependent = [depName];
+        const dep = fragments[0].config.dependencies[0];
+        fragments[0].config.assets[0].type = RESOURCE_TYPE.JS;
+        fragments[0].config.assets[0].dependent = [depName];
         dep.name = depName;
         dep.type = RESOURCE_TYPE.JS;
         dep.loadMethod = RESOURCE_LOADING_TYPE.ON_RENDER_START;
@@ -412,13 +409,13 @@ describe('Resource Injector', () => {
     it("should inject dependency script", () => {
 
         // arrange
-        const fragments = {
-            "f1": FragmentHelper.create()
-        };
+        const fragments = [
+            FragmentHelper.create()
+        ];
         const depName = faker.lorem.word();
-        const dep = fragments.f1.config.dependencies[0];
-        fragments.f1.config.assets[0].type = RESOURCE_TYPE.JS;
-        fragments.f1.config.assets[0].dependent = [depName];
+        const dep = fragments[0].config.dependencies[0];
+        fragments[0].config.assets[0].type = RESOURCE_TYPE.JS;
+        fragments[0].config.assets[0].dependent = [depName];
         dep.name = depName;
         dep.type = RESOURCE_TYPE.JS;
         sandbox.stub(ResourceFactory.instance, "get").callsFake( (): any => dep);
@@ -437,12 +434,12 @@ describe('Resource Injector', () => {
     it("should not inject asset at page render start if load method does not exists", () => {
 
         // arrange
-        const fragments = {
-            "f1": FragmentHelper.create()
-        };
-        delete fragments.f1.config.assets[0].loadMethod;
-        fragments.f1.config.assets[0].type = RESOURCE_TYPE.JS;
-        let assets: any = fragments.f1.config.assets;
+        const fragments = [
+            FragmentHelper.create()
+        ];
+        delete fragments[0].config.assets[0].loadMethod;
+        fragments[0].config.assets[0].type = RESOURCE_TYPE.JS;
+        let assets: any = fragments[0].config.assets;
 
         // act
         const dom = cheerio.load("<html><head></head><body></body></html>");
@@ -451,7 +448,7 @@ describe('Resource Injector', () => {
         assets = assets.filter((asset) => asset.type === RESOURCE_TYPE.JS);
 
         // assert
-        const script = dom("body").children(`script[puzzle-dependency=${fragments.f1.config.assets[0].name}]`);
+        const script = dom("body").children(`script[puzzle-dependency=${fragments[0].config.assets[0].name}]`);
         expect(dom("body").children().length).toBe(assets.length - 1);
         expect(script.attr()).toBe(undefined);
 

--- a/tests/template.spec.ts
+++ b/tests/template.spec.ts
@@ -33,27 +33,27 @@ describe('Template', () => {
       gateways: {
         Browsing: {
           gateway: null,
-          ready: false
-        }
-      },
-      fragments: {
-        product: {
-          gateway: 'Browsing',
-          instance: {
-            "_attributes": {
-              "from": "Browsing",
-              "name": "product",
-            },
-            clientAsync: false,
-            clientAsyncForce: false,
-            asyncDecentralized: false,
-            criticalCss: false,
-            onDemand: false,
-            name: 'product',
-            primary: false,
-            shouldWait: false,
-            from: "Browsing",
-            static: false
+          ready: false,
+          fragments: {
+            product: {
+              gateway: 'Browsing',
+              instance: {
+                "_attributes": {
+                  "from": "Browsing",
+                  "name": "product",
+                },
+                clientAsync: false,
+                clientAsyncForce: false,
+                asyncDecentralized: false,
+                criticalCss: false,
+                onDemand: false,
+                name: 'product',
+                primary: false,
+                shouldWait: false,
+                from: "Browsing",
+                static: false
+              }
+            }
           }
         }
       }
@@ -79,7 +79,7 @@ describe('Template', () => {
 
   it('should compile page with Intersection Observer options', async () => {
     const fragmentSentryConfig: Record<string, FragmentSentryConfig> = { product: FragmentSentryConfig.CLIENT_ASYNC };
-    
+
     const intersectionObserverOptions: IntersectionObserverInit = {
       rootMargin: "500px",
     }
@@ -89,24 +89,24 @@ describe('Template', () => {
       gateways: {
         Browsing: {
           gateway: null,
-          ready: false
-        }
-      },
-      fragments: {
-        product: {
-          gateway: 'Browsing',
-          instance: {
-            "_attributes": {},
-            clientAsync: true,
-            clientAsyncForce: false,
-            asyncDecentralized: false,
-            criticalCss: false,
-            onDemand: false,
-            name: 'product',
-            primary: false,
-            shouldWait: true,
-            from: "Browsing",
-            static: false
+          ready: false,
+          fragments: {
+            product: {
+              gateway: 'Browsing',
+              instance: {
+                "_attributes": {},
+                clientAsync: true,
+                clientAsyncForce: false,
+                asyncDecentralized: false,
+                criticalCss: false,
+                onDemand: false,
+                name: 'product',
+                primary: false,
+                shouldWait: true,
+                from: "Browsing",
+                static: false
+              }
+            }
           }
         }
       }
@@ -122,28 +122,28 @@ describe('Template', () => {
       gateways: {
         Browsing: {
           gateway: null,
-          ready: false
-        }
-      },
-      fragments: {
-        product: {
-          gateway: 'Browsing',
-          instance: {
-            "_attributes": {
-              "from": "Browsing",
-              "name": "product",
-              "primary": "",
-            },
-            clientAsync: false,
-            clientAsyncForce: false,
-            asyncDecentralized: false,
-            criticalCss: false,
-            onDemand: false,
-            name: 'product',
-            primary: true,
-            shouldWait: true,
-            from: "Browsing",
-            static: false
+          ready: false,
+          fragments: {
+            product: {
+              gateway: 'Browsing',
+              instance: {
+                "_attributes": {
+                  "from": "Browsing",
+                  "name": "product",
+                  "primary": "",
+                },
+                clientAsync: false,
+                clientAsyncForce: false,
+                asyncDecentralized: false,
+                criticalCss: false,
+                onDemand: false,
+                name: 'product',
+                primary: true,
+                shouldWait: true,
+                from: "Browsing",
+                static: false
+              }
+            }
           }
         }
       }
@@ -158,28 +158,28 @@ describe('Template', () => {
       gateways: {
         Browsing: {
           gateway: null,
-          ready: false
-        }
-      },
-      fragments: {
-        product: {
-          gateway: 'Browsing',
-          instance: {
-            "_attributes": {
-              "from": "Browsing",
-              "name": "product",
-              "if": "${'false'}"
-            },
-            clientAsync: false,
-            clientAsyncForce: false,
-            asyncDecentralized: false,
-            criticalCss: false,
-            onDemand: false,
-            name: 'product',
-            primary: false,
-            shouldWait: false,
-            from: "Browsing",
-            static: false
+          ready: false,
+          fragments: {
+            product: {
+              gateway: 'Browsing',
+              instance: {
+                "_attributes": {
+                  "from": "Browsing",
+                  "name": "product",
+                  "if": "${'false'}"
+                },
+                clientAsync: false,
+                clientAsyncForce: false,
+                asyncDecentralized: false,
+                criticalCss: false,
+                onDemand: false,
+                name: 'product',
+                primary: false,
+                shouldWait: false,
+                from: "Browsing",
+                static: false
+              }
+            }
           }
         }
       }
@@ -193,28 +193,28 @@ describe('Template', () => {
       gateways: {
         Browsing: {
           gateway: null,
-          ready: false
-        }
-      },
-      fragments: {
-        product: {
-          gateway: 'Browsing',
-          instance: {
-            "_attributes": {
-              "from": "Browsing",
-              "name": "product",
-              "enable-redirect": ""
-            },
-            clientAsync: false,
-            clientAsyncForce: false,
-            asyncDecentralized: false,
-            criticalCss: false,
-            onDemand: false,
-            name: 'product',
-            primary: false,
-            shouldWait: false,
-            from: "Browsing",
-            static: false
+          ready: false,
+          fragments: {
+            product: {
+              gateway: 'Browsing',
+              instance: {
+                "_attributes": {
+                  "from": "Browsing",
+                  "name": "product",
+                  "enable-redirect": ""
+                },
+                clientAsync: false,
+                clientAsyncForce: false,
+                asyncDecentralized: false,
+                criticalCss: false,
+                onDemand: false,
+                name: 'product',
+                primary: false,
+                shouldWait: false,
+                from: "Browsing",
+                static: false
+              }
+            }
           }
         }
       }
@@ -228,24 +228,24 @@ describe('Template', () => {
       gateways: {
         Browsing: {
           gateway: null,
-          ready: false
-        }
-      },
-      fragments: {
-        product: {
-          gateway: 'Browsing',
-          instance: {
-            "_attributes": {},
-            clientAsync: true,
-            clientAsyncForce: true,
-            asyncDecentralized: false,
-            criticalCss: false,
-            onDemand: false,
-            name: 'product',
-            primary: false,
-            shouldWait: true,
-            from: "Browsing",
-            static: false
+          ready: false,
+          fragments: {
+            product: {
+              gateway: 'Browsing',
+              instance: {
+                "_attributes": {},
+                clientAsync: true,
+                clientAsyncForce: true,
+                asyncDecentralized: false,
+                criticalCss: false,
+                onDemand: false,
+                name: 'product',
+                primary: false,
+                shouldWait: true,
+                from: "Browsing",
+                static: false
+              }
+            }
           }
         }
       }
@@ -259,24 +259,24 @@ describe('Template', () => {
       gateways: {
         Browsing: {
           gateway: null,
-          ready: false
-        }
-      },
-      fragments: {
-        product: {
-          gateway: 'Browsing',
-          instance: {
-            "_attributes": {},
-            clientAsync: true,
-            clientAsyncForce: false,
-            criticalCss: false,
-            onDemand: true,
-            asyncDecentralized: false,
-            name: 'product',
-            primary: false,
-            shouldWait: true,
-            from: "Browsing",
-            static: false
+          ready: false,
+          fragments: {
+            product: {
+              gateway: 'Browsing',
+              instance: {
+                "_attributes": {},
+                clientAsync: true,
+                clientAsyncForce: false,
+                criticalCss: false,
+                onDemand: true,
+                asyncDecentralized: false,
+                name: 'product',
+                primary: false,
+                shouldWait: true,
+                from: "Browsing",
+                static: false
+              }
+            }
           }
         }
       }
@@ -290,24 +290,24 @@ describe('Template', () => {
       gateways: {
         Browsing: {
           gateway: null,
-          ready: false
-        }
-      },
-      fragments: {
-        product: {
-          gateway: 'Browsing',
-          instance: {
-            "_attributes": {},
-            clientAsync: true,
-            clientAsyncForce: false,
-            criticalCss: true,
-            onDemand: false,
-            asyncDecentralized: false,
-            name: 'product',
-            primary: false,
-            shouldWait: true,
-            from: "Browsing",
-            static: false
+          ready: false,
+          fragments: {
+            product: {
+              gateway: 'Browsing',
+              instance: {
+                "_attributes": {},
+                clientAsync: true,
+                clientAsyncForce: false,
+                criticalCss: true,
+                onDemand: false,
+                asyncDecentralized: false,
+                name: 'product',
+                primary: false,
+                shouldWait: true,
+                from: "Browsing",
+                static: false
+              }
+            }
           }
         }
       }
@@ -346,28 +346,28 @@ describe('Template', () => {
       gateways: {
         Browsing: {
           gateway: null,
-          ready: false
-        }
-      },
-      fragments: {
-        product: {
-          gateway: 'Browsing',
-          instance: {
-            "_attributes": {
-              "from": "Browsing",
-              "name": "product",
-              "partial": "notification",
-            },
-            clientAsync: false,
-            clientAsyncForce: false,
-            asyncDecentralized: false,
-            criticalCss: false,
-            onDemand: false,
-            name: 'product',
-            primary: true,
-            shouldWait: true,
-            from: "Browsing",
-            static: false
+          ready: false,
+          fragments: {
+            product: {
+              gateway: 'Browsing',
+              instance: {
+                "_attributes": {
+                  "from": "Browsing",
+                  "name": "product",
+                  "partial": "notification",
+                },
+                clientAsync: false,
+                clientAsyncForce: false,
+                asyncDecentralized: false,
+                criticalCss: false,
+                onDemand: false,
+                name: 'product',
+                primary: true,
+                shouldWait: true,
+                from: "Browsing",
+                static: false
+              }
+            }
           }
         }
       }
@@ -388,28 +388,28 @@ describe('Template', () => {
       gateways: {
         Browsing: {
           gateway: null,
-          ready: false
-        }
-      },
-      fragments: {
-        product: {
-          gateway: 'Browsing',
-          instance: {
-            "_attributes": {
-              "from": "Browsing",
-              "name": "product",
-              "shouldwait": "",
-            },
-            clientAsync: false,
-            clientAsyncForce: false,
-            asyncDecentralized: false,
-            criticalCss: false,
-            onDemand: false,
-            name: 'product',
-            primary: false,
-            shouldWait: true,
-            from: "Browsing",
-            static: false
+          ready: false,
+          fragments: {
+            product: {
+              gateway: 'Browsing',
+              instance: {
+                "_attributes": {
+                  "from": "Browsing",
+                  "name": "product",
+                  "shouldwait": "",
+                },
+                clientAsync: false,
+                clientAsyncForce: false,
+                asyncDecentralized: false,
+                criticalCss: false,
+                onDemand: false,
+                name: 'product',
+                primary: false,
+                shouldWait: true,
+                from: "Browsing",
+                static: false
+              }
+            }
           }
         }
       }
@@ -432,28 +432,28 @@ describe('Template', () => {
       gateways: {
         Browsing: {
           gateway: null,
-          ready: false
-        }
-      },
-      fragments: {
-        product: {
-          gateway: 'Browsing',
-          instance: {
-            "_attributes": {
-              "from": "Browsing",
-              "name": "product",
-              "partial": "a",
-            },
-            clientAsync: false,
-            clientAsyncForce: false,
-            asyncDecentralized: false,
-            criticalCss: false,
-            onDemand: false,
-            name: 'product',
-            primary: false,
-            shouldWait: true,
-            from: "Browsing",
-            static: false
+          ready: false,
+          fragments: {
+            product: {
+              gateway: 'Browsing',
+              instance: {
+                "_attributes": {
+                  "from": "Browsing",
+                  "name": "product",
+                  "partial": "a",
+                },
+                clientAsync: false,
+                clientAsyncForce: false,
+                asyncDecentralized: false,
+                criticalCss: false,
+                onDemand: false,
+                name: 'product',
+                primary: false,
+                shouldWait: true,
+                from: "Browsing",
+                static: false
+              }
+            }
           }
         }
       }
@@ -543,24 +543,24 @@ describe('Template', () => {
       gateways: {
         Browsing: {
           gateway: null,
-          ready: false
-        }
-      },
-      fragments: {
-        product: {
-          gateway: 'Browsing',
-          instance: {
-            _attributes: {"from": "Browsing", "name": "product", "partial": "meta"},
-            name: 'product',
-            clientAsync: false,
-            clientAsyncForce: false,
-            asyncDecentralized: false,
-            criticalCss: false,
-            onDemand: false,
-            primary: false,
-            shouldWait: true,
-            from: "Browsing",
-            static: false
+          ready: false,
+          fragments: {
+            product: {
+              gateway: 'Browsing',
+              instance: {
+                _attributes: {"from": "Browsing", "name": "product", "partial": "meta"},
+                name: 'product',
+                clientAsync: false,
+                clientAsyncForce: false,
+                asyncDecentralized: false,
+                criticalCss: false,
+                onDemand: false,
+                primary: false,
+                shouldWait: true,
+                from: "Browsing",
+                static: false
+              }
+            }
           }
         }
       }
@@ -592,7 +592,7 @@ describe('Template', () => {
 
     template.getDependencies();
 
-    template.fragments.product.update({
+    template.fragments.find(f => f.name === "product")!.update({
       render: {
         url: '/',
         static: true
@@ -642,7 +642,7 @@ describe('Template', () => {
 
     template.getDependencies();
 
-    template.fragments.product.update({
+    template.fragments.find(f => f.name === "product")!.update({
       render: {
         url: '/',
         static: true
@@ -701,7 +701,7 @@ describe('Template', () => {
 
     template.getDependencies();
 
-    template.fragments.product.update({
+    template.fragments.find(f => f.name === "product")!.update({
       render: {
         url: '/',
         static: true
@@ -751,7 +751,7 @@ describe('Template', () => {
 
     template.getDependencies();
 
-    template.fragments.product.update({
+    template.fragments.find(f => f.name === "product")!.update({
       render: {
         url: '/'
       },
@@ -772,7 +772,7 @@ describe('Template', () => {
     template.compile({}).then(handler => {
       handler({}, createExpressMock({
         write(str: string) {
-          expect(str).to.eq(`<div><div id="product" puzzle-fragment="product" puzzle-gateway="Browsing" puzzle-chunk="product_main"></div></div>`);
+          expect(str).to.eq(`<div>  </div>`);
         },
         end(str: string) {
           expect(str).to.eq(`<script>PuzzleJs.emit('0');</script></body></html>`);
@@ -808,7 +808,7 @@ describe('Template', () => {
 
     template.getDependencies();
 
-    template.fragments.product.update({
+    template.fragments.find(f => f.name === "product")!.update({
       render: {
         url: '/'
       },
@@ -832,7 +832,7 @@ describe('Template', () => {
           expect(str).to.eq(null);
         },
         end(str: string) {
-          expect(str).to.eq(`<div><div id="product" puzzle-fragment="product" puzzle-gateway="Browsing"></div></div>`);
+          expect(str).to.eq(`<div>  </div>`);
           done();
         },
         status: () => ''
@@ -865,7 +865,7 @@ describe('Template', () => {
 
     template.getDependencies();
 
-    template.fragments.product.update({
+    template.fragments.find(f => f.name === "product")!.update({
       render: {
         url: '/',
         static: true
@@ -922,7 +922,7 @@ describe('Template', () => {
 
     template.getDependencies();
 
-    template.fragments.product.update({
+    template.fragments.find(f => f.name === "product")!.update({
       render: {
         url: '/',
         static: true
@@ -1005,7 +1005,7 @@ describe('Template', () => {
 
         template.getDependencies();
 
-        template.fragments.product.update({
+        template.fragments.find(f => f.name === "product")!.update({
           render: {
             url: '/'
           },
@@ -1064,7 +1064,7 @@ describe('Template', () => {
 
         template.getDependencies();
 
-        template.fragments.product.update({
+        template.fragments.find(f => f.name === "product")!.update({
           render: {
             url: '/'
           },
@@ -1128,7 +1128,7 @@ describe('Template', () => {
 
         template.getDependencies();
 
-        template.fragments.product.update({
+        template.fragments.find(f => f.name === "product")!.update({
           render: {
             url: '/'
           },
@@ -1138,7 +1138,7 @@ describe('Template', () => {
           version: '1.0.0'
         }, 'http://my-test-gateway.com', 'gateway');
 
-        template.fragments.product2.update({
+        template.fragments.find(f => f.name === "product2")!.update({
           render: {
             url: '/'
           },
@@ -1195,7 +1195,7 @@ describe('Template', () => {
 
         template.getDependencies();
 
-        template.fragments.product.update({
+        template.fragments.find(f => f.name === "product")!.update({
           render: {
             url: '/'
           },
@@ -1265,7 +1265,7 @@ describe('Template', () => {
 
         template.getDependencies();
 
-        template.fragments.product.update({
+        template.fragments.find(f => f.name === "product")!.update({
           render: {
             url: '/'
           },
@@ -1275,7 +1275,7 @@ describe('Template', () => {
           version: '1.0.0'
         }, 'http://my-test-gateway.com', 'gateway');
 
-        template.fragments.header.update({
+        template.fragments.find(f => f.name === "header")!.update({
           render: {
             url: '/'
           },
@@ -1338,7 +1338,7 @@ describe('Template', () => {
 
         template.getDependencies();
 
-        template.fragments.product.update({
+        template.fragments.find(f => f.name === "product")!.update({
           render: {
             url: '/',
             placeholder: false
@@ -1408,7 +1408,7 @@ describe('Template', () => {
 
         template.getDependencies();
 
-        template.fragments.product.update({
+        template.fragments.find(f => f.name === "product")!.update({
           render: {
             url: '/',
             placeholder: true
@@ -1481,7 +1481,7 @@ describe('Template', () => {
 
         template.getDependencies();
 
-        template.fragments.product.update({
+        template.fragments.find(f => f.name === "product")!.update({
           render: {
             url: '/',
             placeholder: true
@@ -1561,7 +1561,7 @@ describe('Template', () => {
 
         template.getDependencies();
 
-        template.fragments.product.update({
+        template.fragments.find(f => f.name === "product")!.update({
           render: {
             url: '/',
           },
@@ -1571,7 +1571,7 @@ describe('Template', () => {
           version: '1.0.0'
         }, 'http://my-test-gateway-chunked-2.com', 'gateway');
 
-        template.fragments.header.update({
+        template.fragments.find(f => f.name === "header")!.update({
           render: {
             url: '/',
           },
@@ -1581,7 +1581,7 @@ describe('Template', () => {
           version: '1.0.0'
         }, 'http://my-test-gateway-chunked-2.com', 'gateway');
 
-        template.fragments.footer.update({
+        template.fragments.find(f => f.name === "footer")!.update({
           render: {
             url: '/',
           },
@@ -1657,7 +1657,7 @@ describe('Template', () => {
 
         template.getDependencies();
 
-        template.fragments.product.update({
+        template.fragments.find(f => f.name === "product")!.update({
           render: {
             url: '/',
             placeholder: true
@@ -1726,7 +1726,7 @@ describe('Template', () => {
 
         template.getDependencies();
 
-        template.fragments['product-not-exists'].update({
+        template.fragments.find(f => f.name === 'product-not-exists')!.update({
           render: {
             url: '/',
             placeholder: false


### PR DESCRIPTION
#### What's this PR do?

* Updates the `@puzzle-js/client-lib` dependency to its latest version.
*  Improves the issues of `fragment if attribute`
    *  CSS assets injecting into the dom on page creation. This makes it not possible to control their behavior. This change wraps those assets with `if` template wrappers.
    * Also wraps fragments with if template expressions that have if attributes. This solves most of the issues with client-side rendering or hydration. (For two fragments with the same name).
* Sends gateway information on different actions/configs to the client library if needed
* On the template, it saves fragments by both their gateway name and fragment name. Then it flattens all fragments into a single array. This improves lots of places that convert object values to an array. Also, it makes it possible to use the same fragment name with different gateways, which is helpful for moving fragments between gateways.

#### Where should the reviewer start?

* Reviewer could skip test refactors, which are primarily about new gateway info passes and holding fragments in gateways. 

#### How should this be manually tested?

* It is tested on most scenarios locally. It will also be tested by an internal team that uses puzzlejs.

#### Any background context you want to provide?

* We are making some progressive switches from one gateway to another. Fragment names will be the same and we will use the if attribute to decide on what fragment to load on runtime.
