### PR TITLE
Improve default fragment behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-# [3.60.10] - 19-12-2022
+# [3.61.0] - 21-12-2022
+### Changed
+- Default behavior for fragments changed as *shouldWait enabled*. (Unstable `chunked` attribute can be used to force previous behavior)
+- Improvements on the fragment `if` attribute
+
+# [3.60.0] - 19-12-2022
 ### Changed
 - Template dependencies recognition and structure refactor.
-- Improvements on the fragment if attribute
+- Improvements on the fragment `if` attribute
 
 # [3.52.0] - 22-11-2022
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puzzle-js/core",
-  "version": "3.60.0",
+  "version": "3.61.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "logo": "https://image.ibb.co/jM29on/puzzlelogo.png",

--- a/src/template.ts
+++ b/src/template.ts
@@ -332,7 +332,7 @@ export class Template {
 
       let fragmentContent;
       if ((typeof attributes.if === "boolean" && !attributes.if) || attributes.if === "false") {
-        fragmentContent = "";
+        return;
       } else {
         fragmentContent = await waitedFragmentReplacement.fragment.getContent(attributes, req);
       }

--- a/src/template.ts
+++ b/src/template.ts
@@ -111,7 +111,7 @@ export class Template {
           gateways[from].fragments[fragmentName].static = true;
         }
       } else {
-        gateways[from].fragments[fragmentName].shouldWait = true;
+        gateways[from].fragments[fragmentName].shouldWait = typeof fragment.attribs.chunked === 'undefined';
 
         if (!gateways[from].fragments[fragmentName].primary) {
           if (typeof fragment.attribs.primary !== 'undefined') {

--- a/src/template.ts
+++ b/src/template.ts
@@ -111,23 +111,19 @@ export class Template {
           gateways[from].fragments[fragmentName].static = true;
         }
       } else {
+        gateways[from].fragments[fragmentName].shouldWait = true;
+
         if (!gateways[from].fragments[fragmentName].primary) {
           if (typeof fragment.attribs.primary !== 'undefined') {
             if (primaryName != null && primaryName !== fragment.attribs.name) throw new PuzzleError(ERROR_CODES.MULTIPLE_PRIMARY_FRAGMENTS);
             primaryName = fragment.attribs.name;
             gateways[from].fragments[fragmentName].primary = true;
-            gateways[from].fragments[fragmentName].shouldWait = true;
           }
-        }
-
-        if (!gateways[from].fragments[fragmentName].shouldWait) {
-          gateways[from].fragments[fragmentName].shouldWait = typeof fragment.attribs.shouldwait !== 'undefined' || (fragment.parent && fragment.parent.name === 'head') || false;
         }
 
         if (gateways[from].fragments[fragmentName].clientAsync || (typeof fragment.attribs['client-async'] !== "undefined" || typeof fragment.attribs['async-c2'] !== "undefined")) {
           gateways[from].fragments[fragmentName].attributes = Object.assign(gateways[from].fragments[fragmentName].attributes, fragment.attribs);
           gateways[from].fragments[fragmentName].primary = false;
-          gateways[from].fragments[fragmentName].shouldWait = true;
           gateways[from].fragments[fragmentName].clientAsync = true;
           gateways[from].fragments[fragmentName].clientAsyncForce = gateways[from].fragments[fragmentName].clientAsyncForce || typeof fragment.attribs['client-async-force'] !== "undefined";
           gateways[from].fragments[fragmentName].criticalCss = gateways[from].fragments[fragmentName].criticalCss || typeof fragment.attribs['critical-css'] !== "undefined";

--- a/tests/integration/sf.spec.ts
+++ b/tests/integration/sf.spec.ts
@@ -172,7 +172,7 @@ describe('Storefront', () => {
             pages: [
                 {
                     url: '/',
-                    html: '<template><div><html><head></head><body><fragment from="Browsing" name="product"/></div></body></html></template>'
+                    html: '<template><div><html><head></head><body><fragment from="Browsing" name="product" chunked /></div></body></html></template>'
                 }
             ]
         } as any);
@@ -309,7 +309,7 @@ describe('Storefront', () => {
             pages: [
                 {
                     url: ['/', '/detail'],
-                    html: `<template><html><head></head><body><fragment from="Browsing" name="${fragment.name}" primary/></div></body></html></template>`
+                    html: `<template><html><head></head><body><fragment from="Browsing" name="${fragment.name}" primary /></div></body></html></template>`
                 }
             ]
         } as any);

--- a/tests/page.spec.ts
+++ b/tests/page.spec.ts
@@ -59,7 +59,7 @@ describe('Page', () => {
                 criticalCss: false,
                 onDemand: false,
                 primary: false,
-                shouldWait: false,
+                shouldWait: true,
                 from: "Browsing",
                 static: false
               }
@@ -78,7 +78,7 @@ describe('Page', () => {
                 asyncDecentralized: false,
                 criticalCss: false,
                 onDemand: false,
-                shouldWait: false,
+                shouldWait: true,
                 from: "Browsing",
                 static: false
               }
@@ -97,7 +97,7 @@ describe('Page', () => {
                 asyncDecentralized: false,
                 criticalCss: false,
                 onDemand: false,
-                shouldWait: false,
+                shouldWait: true,
                 from: "Browsing",
                 static: false
               }

--- a/tests/system/system.spec.ts
+++ b/tests/system/system.spec.ts
@@ -65,7 +65,7 @@ describe('System Tests', () => {
       pages: [
         {
           url: '/',
-          html: '<template><html><head></head><body><fragment from="Browsing" name="example"></fragment></body></html></template>'
+          html: '<template><html><head></head><body><fragment from="Browsing" name="example" chunked></fragment></body></html></template>'
         }
       ],
       serverOptions: {
@@ -101,7 +101,7 @@ describe('System Tests', () => {
         });
     });
   });
-  
+
 
   it('should render single static fragment using HTTPS', (done) => {
     const gatewayConfigurator = new GatewayConfigurator();
@@ -158,7 +158,7 @@ describe('System Tests', () => {
       pages: [
         {
           url: '/',
-          html: '<template><html><head></head><body><fragment from="Browsing" name="example"></fragment></body></html></template>'
+          html: '<template><html><head></head><body><fragment from="Browsing" name="example" chunked></fragment></body></html></template>'
         }
       ],
       serverOptions: {

--- a/tests/template.spec.ts
+++ b/tests/template.spec.ts
@@ -49,7 +49,7 @@ describe('Template', () => {
                 onDemand: false,
                 name: 'product',
                 primary: false,
-                shouldWait: false,
+                shouldWait: true,
                 from: "Browsing",
                 static: false
               }
@@ -175,7 +175,7 @@ describe('Template', () => {
                 onDemand: false,
                 name: 'product',
                 primary: false,
-                shouldWait: false,
+                shouldWait: true,
                 from: "Browsing",
                 static: false
               }
@@ -210,7 +210,7 @@ describe('Template', () => {
                 onDemand: false,
                 name: 'product',
                 primary: false,
-                shouldWait: false,
+                shouldWait: true,
                 from: "Browsing",
                 static: false
               }
@@ -744,7 +744,7 @@ describe('Template', () => {
     const template = new Template(`
                 <template>
                     <div>
-                        <fragment from="Browsing" name="product" if="${false}"> </fragment>
+                        <fragment from="Browsing" name="product" if="${false}" chunked> </fragment>
                     </div>
                 </template>
             `);
@@ -1329,7 +1329,7 @@ describe('Template', () => {
                             </head>
                             <body>
                             <div>
-                                <fragment from="Browsing" name="product"></fragment>
+                                <fragment from="Browsing" name="product" chunked></fragment>
                             </div>
                             </body>
                         </html>
@@ -1399,7 +1399,7 @@ describe('Template', () => {
                             </head>
                             <body>
                             <div>
-                                <fragment from="Browsing" name="product"></fragment>
+                                <fragment from="Browsing" name="product" chunked></fragment>
                             </div>
                             </body>
                         </html>
@@ -1553,7 +1553,7 @@ describe('Template', () => {
                                 <div>
                                     <fragment from="Browsing" name="product"></fragment>
                                 </div>
-                                <fragment from="Browsing" name="footer"></fragment>
+                                <fragment from="Browsing" name="footer" chunked></fragment>
                             </body>
                         </html>
                     </template>
@@ -1644,12 +1644,12 @@ describe('Template', () => {
                                 
                             </head>
                             <body>
-                                <fragment from="Browsing" name="product" partial="header"></fragment>
-                                <fragment from="Browsing" name="product"></fragment>
+                                <fragment from="Browsing" name="product" partial="header" chunked></fragment>
+                                <fragment from="Browsing" name="product" chunked></fragment>
                                 <div>
-                                    <fragment from="Browsing" name="product" partial="side"></fragment>
+                                    <fragment from="Browsing" name="product" partial="side" chunked></fragment>
                                 </div>
-                                <fragment from="Browsing" name="product" partial="footer"></fragment>
+                                <fragment from="Browsing" name="product" partial="footer" chunked></fragment>
                             </body>
                         </html>
                     </template>


### PR DESCRIPTION
#### What's this PR do?

* Currently, a fragment must have either the `shouldWait` or the `client-async` attribute to work properly. They are categorized as chunked without these properties, and currently, it is working unstable. To solve this, this change makes `shouldWait` a default property. If still needed; chunked property can be used, but still, it is not working as expected, so maybe it can be removed in the future.
* It also improves a bug I noticed with primary fragments that have if attributes.

#### Where should the reviewer start?

* Reviewer can focus on the changes at the template.ts since the others are changed regarding those. I didn't want to remove the chunked tests since they are testing some core functionality. They can be refactored as `shouldWait` in the near future.

#### How should this be manually tested?

* It is tested with some different usages locally. It will be tested by an internal team after it's published.
