### PR TITLE
fix: improve user space types of the bff/fragment middlewares

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puzzle-js/core",
-  "version": "3.61.0",
+  "version": "3.61.1",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "logo": "https://image.ibb.co/jM29on/puzzlelogo.png",

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,7 @@ export interface IFragmentBFFRender {
     url: string | string[];
     routeCache?: number;
     selfReplace?: boolean;
-    middlewares?: Array<(req: Request, res: Response, next: NextFunction) => any | string>;
+    middlewares?: Array<((req: Request, res: Response, next: NextFunction) => any) | string>;
     cacheControl?: string;
     placeholder?: boolean;
     error?: boolean;
@@ -136,7 +136,7 @@ export type IFragmentEndpointHandler = (req: any, res: any, next?: any) => void;
 
 export interface IApiHandler {
     path: string;
-    middlewares: Array<(req: Request, res: Response, next: NextFunction) => void>;
+    middlewares: Array<((req: Request, res: Response, next: NextFunction) => void) | string>;
     method: HTTP_METHODS;
     cacheControl?: string;
     routeCache?: number;


### PR DESCRIPTION
#### What's this PR do?

* Fixes the user space types of middleware. Currently, it is misleading users to set the middleware instead of the name that has been set on the inversify container.

#### How should this be manually tested?

* There should be no need to test manually since it only affects the typescript developer experience.

#### Any background context you want to provide?

* The applications I observed asserts the middlewares to `any` or `newer` to bypass the type mismatch. This change should fix that issue.
