### PR TITLE
refactor: use asset's link attribute first at the preview mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puzzle-js/core",
-  "version": "3.61.1",
+  "version": "3.62.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "logo": "https://image.ibb.co/jM29on/puzzlelogo.png",

--- a/src/gatewayBFF.ts
+++ b/src/gatewayBFF.ts
@@ -227,7 +227,7 @@ export class GatewayBFF {
     }));
 
     fragmentVersion.assets.forEach(asset => {
-      const assetUrl = asset.fileName ?  `/${fragment.name}/static/${asset.fileName}` : asset.link;
+      const assetUrl = asset.link || `/${fragment.name}/static/${asset.fileName}`;
       if (asset.type === RESOURCE_TYPE.JS) {
         dom('body').append(`<script puzzle-asset="${asset.name}" src="${assetUrl}" type="text/javascript"${RESOURCE_JS_EXECUTE_TYPE.SYNC}></script>`);
       } else if (asset.type === RESOURCE_TYPE.CSS) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,7 +67,7 @@ export interface IFileResourceDependency extends IFileResource {
 
 export interface IFileResourceAsset extends IFileResource {
     fileName?: string;
-    link: string;
+    link?: string;
     loadMethod: RESOURCE_LOADING_TYPE;
     type: RESOURCE_TYPE;
     name: string;

--- a/tests/gateway.spec.ts
+++ b/tests/gateway.spec.ts
@@ -585,14 +585,12 @@ describe('Gateway', () => {
                                 assets: [
                                     {
                                         fileName: 'test-asset-1-filename.js',
-                                        link: 'test-asset-1-link.js',
                                         loadMethod: RESOURCE_LOADING_TYPE.ON_RENDER_START,
                                         type: RESOURCE_TYPE.JS,
                                         name: 'test-asset-1-name',
                                     },
                                     {
                                         fileName: 'test-asset-2-filename.css',
-                                        link: 'test-asset-2-link.css',
                                         loadMethod: RESOURCE_LOADING_TYPE.ON_RENDER_START,
                                         type: RESOURCE_TYPE.CSS,
                                         name: 'test-asset-2-name',
@@ -629,7 +627,7 @@ describe('Gateway', () => {
             }) as any,{});
         });
 
-        it('should render fragment in preview mode with given assets without filename', async () => {
+        it('should render fragment in preview mode with given assets with link', async () => {
             const gatewayConfiguration: IGatewayBFFConfiguration = {
                 ...commonGatewayConfiguration,
                 fragments: [


### PR DESCRIPTION
#### What's this PR do?

* Evey section that uses the `fileName` property of assets checks the `link` attribute first, except in preview mode. It still tries to use fileName first, which creates inconsistency. This pr will improve that behavior.

#### How should this be manually tested?

* It is tested manually with linking, and it works fine. I also checked multiple gateways across teams to check if there were other use cases. It can be done similarly.
* 
#### Any background context you want to provide?

* Our team recently switched to HTTPS locally, and this inconsistency brokes preview mode usage. Most teams already give proper link property for local env, so this should not affect workflows.

#### What are the relevant tickets?
* -
#### Screenshots (if appropriate)
* -
