### PR TITLE
fix: forward-compatibility adaptation for request headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puzzle-js/core",
-  "version": "3.62.1",
+  "version": "3.62.2",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "logo": "https://image.ibb.co/jM29on/puzzlelogo.png",

--- a/src/fragment.ts
+++ b/src/fragment.ts
@@ -137,7 +137,13 @@ export class FragmentBFF extends Fragment {
    * @returns {*}
    */
   private clearRequest(req: express.Request) {
-    const clearedReq = Object.assign({}, req);
+    const clearedReq = Object.assign(
+      {
+        headers: req.headers
+      },
+      req
+    );
+    
     if (req.query) {
       delete clearedReq.query[RENDER_MODE_QUERY_NAME];
       delete clearedReq.query[PREVIEW_PARTIAL_QUERY_NAME];


### PR DESCRIPTION
#### What's this PR do?

* - when we started to use node 18, headers were coming as undefined. we realized that it was caused by [these changes](https://github.com/nodejs/node/pull/35281) on nodejs.

#### Where should the reviewer start?
* -
#### How should this be manually tested?
* -
#### Any background context you want to provide?
* - you can find more details in [this issue](https://github.com/nodejs/node/issues/36550)
#### What are the relevant tickets?
* -
#### Screenshots (if appropriate)
* -
