### PR TITLE
feat: improve fragment preview mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+# [3.63.2] - 06-01-2024
+### Changed
+- Improvements on the fragment preview mode by adding `puzzle-fragment` and `fragment-partial` attributes.
+
 # [3.63.0] - 24-11-2023
 ### Removed
 - Sentry configuration has been removed. (socket.io-client package removed)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puzzle-js/core",
-  "version": "3.63.1",
+  "version": "3.63.2",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "logo": "https://image.ibb.co/jM29on/puzzlelogo.png",

--- a/src/gatewayBFF.ts
+++ b/src/gatewayBFF.ts
@@ -193,7 +193,7 @@ export class GatewayBFF {
         } else {
           if (gatewayContent.content[partial]) {
             res.status(HTTP_STATUS_CODE.OK);
-            res.send(this.wrapFragmentContent(gatewayContent.content[partial].toString(), fragment, version, gatewayContent.$model));
+            res.send(this.wrapFragmentContent(gatewayContent.content[partial].toString(), fragment, version, gatewayContent.$model, partial));
           } else {
             res.status(HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR);
             res.send(`Partial ${partial} doesn't exist in fragment response`);
@@ -213,8 +213,8 @@ export class GatewayBFF {
    * @param model
    * @returns {string}
    */
-  private wrapFragmentContent(htmlContent: string, fragment: FragmentBFF, version: string, model: FragmentModel): string {
-    const dom = cheerio.load(`<html><head><title>${this.config.name} - ${fragment.name}</title>${this.config.isMobile ? '<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />' : ''}${Template.fragmentModelScript(fragment, model, false)}</head><body><div id="${fragment.name}">${htmlContent}</div></body></html>`);
+  private wrapFragmentContent(htmlContent: string, fragment: FragmentBFF, version: string, model: FragmentModel, partialName: string): string {
+    const dom = cheerio.load(`<html><head><title>${this.config.name} - ${fragment.name}</title>${this.config.isMobile ? '<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />' : ''}${Template.fragmentModelScript(fragment, model, false)}</head><body><div id="${fragment.name}" puzzle-fragment="${fragment.name}" fragment-partial="${partialName}">${htmlContent}</div></body></html>`);
 
     const fragmentVersion = fragment.config.versions[version];
 

--- a/tests/fragments/boutique-list/test-with-partials/index.ts
+++ b/tests/fragments/boutique-list/test-with-partials/index.ts
@@ -1,0 +1,16 @@
+module.exports = {
+    content(){
+        return {
+            main: 'test3',
+            'other-section': 'other section content'
+        };
+    },
+    data(){
+        return {
+            data: {}
+        };
+    },
+    placeholder(){
+        return "Placeholder";
+    }
+};

--- a/tests/gateway.spec.ts
+++ b/tests/gateway.spec.ts
@@ -416,7 +416,39 @@ describe('Gateway', () => {
             await bffGw.renderFragment({} as any, 'boutique-list', FRAGMENT_RENDER_MODES.PREVIEW, DEFAULT_MAIN_PARTIAL, createExpressMock({
                 send: (gwResponse: string) => {
                     if (!gwResponse) throw new Error('No response from gateway');
-                    expect(gwResponse).to.include(`<title>Browsing - boutique-list</title><meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"></head><body><div id="boutique-list">test</div></body></html>`);
+                    expect(gwResponse).to.include(`<title>Browsing - boutique-list</title><meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"></head><body><div id="boutique-list" puzzle-fragment="boutique-list" fragment-partial="main">test</div></body></html>`);
+                }
+            }) as any,{});
+        });
+
+        it('should render fragment in preview mode with different partial', async () => {
+            const partialName = "other-section";
+            const gatewayConfiguration: IGatewayBFFConfiguration = {
+                ...commonGatewayConfiguration,
+                fragments: [
+                    {
+                        name: 'boutique-list',
+                        version: 'test',
+                        render: {
+                            url: '/'
+                        },
+                        testCookie: 'fragment_test',
+                        versions: {
+                            'test': {
+                                assets: [],
+                                dependencies: [],
+                                handler: require('./fragments/boutique-list/test-with-partials')
+                            }
+                        }
+                    }
+                ]
+            };
+
+            const bffGw = new GatewayBFF(gatewayConfiguration);
+            await bffGw.renderFragment({} as any, 'boutique-list', FRAGMENT_RENDER_MODES.PREVIEW, partialName, createExpressMock({
+                send: (gwResponse: string) => {
+                    if (!gwResponse) throw new Error('No response from gateway');
+                    expect(gwResponse).to.include(`<title>Browsing - boutique-list</title><meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"></head><body><div id="boutique-list" puzzle-fragment="boutique-list" fragment-partial="${partialName}">other section content</div></body></html>`);
                 }
             }) as any,{});
         });
@@ -453,7 +485,7 @@ describe('Gateway', () => {
             await bffGw.renderFragment({} as any, 'boutique-list', FRAGMENT_RENDER_MODES.PREVIEW, DEFAULT_MAIN_PARTIAL, createExpressMock({
                 send: (gwResponse: string) => {
                     if (!gwResponse) throw new Error('No response from gateway');
-                    expect(gwResponse).to.include(`<title>Browsing - boutique-list</title><meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"></head><body><div id="boutique-list">test2</div></body></html>`);
+                    expect(gwResponse).to.include(`<title>Browsing - boutique-list</title><meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"></head><body><div id="boutique-list" puzzle-fragment="boutique-list" fragment-partial="main">test2</div></body></html>`);
                 }
             }) as any,{}, "test2");
         });
@@ -490,7 +522,7 @@ describe('Gateway', () => {
             await bffGw.renderFragment({} as any, 'boutique-list', FRAGMENT_RENDER_MODES.PREVIEW, DEFAULT_MAIN_PARTIAL, createExpressMock({
                 send: (gwResponse: string) => {
                     if (!gwResponse) throw new Error('No response from gateway');
-                    expect(gwResponse).to.include(`<title>Browsing - boutique-list</title><meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"></head><body><div id="boutique-list">test2</div></body></html>`);
+                    expect(gwResponse).to.include(`<title>Browsing - boutique-list</title><meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"></head><body><div id="boutique-list" puzzle-fragment="boutique-list" fragment-partial="main">test2</div></body></html>`);
                 }
             }) as any,{'fragment_test': 'test2'});
         });
@@ -535,7 +567,7 @@ describe('Gateway', () => {
             await bffGw.renderFragment({url: 'test'} as any, 'boutique-list', FRAGMENT_RENDER_MODES.PREVIEW, DEFAULT_MAIN_PARTIAL, createExpressMock({
                 send: (gwResponse: string) => {
                     if (!gwResponse) throw new Error('No response from gateway');
-                    expect(gwResponse).to.include(`<title>Browsing - boutique-list</title><meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"></head><body><div id="boutique-list">Requested:Url:test</div></body></html>`);
+                    expect(gwResponse).to.include(`<title>Browsing - boutique-list</title><meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"></head><body><div id="boutique-list" puzzle-fragment="boutique-list" fragment-partial="main">Requested:Url:test</div></body></html>`);
                 }
             }) as any,{});
         });
@@ -622,7 +654,7 @@ describe('Gateway', () => {
             await bffGw.renderFragment({url: 'test'} as any, 'boutique-list', FRAGMENT_RENDER_MODES.PREVIEW, DEFAULT_MAIN_PARTIAL, createExpressMock({
                 send: (gwResponse: string) => {
                     if (!gwResponse) throw new Error('No response from gateway');
-                    expect(gwResponse).to.include(`<script puzzle-dependency="puzzle-lib" type="text/javascript">puzzleLibScript</script><title>Browsing - boutique-list</title><meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"><link puzzle-asset="test-asset-2-name" rel="stylesheet" href="/boutique-list/static/test-asset-2-filename.css"></head><body><div id="boutique-list">Requested:Url:test</div><script puzzle-asset="test-asset-1-name" src="/boutique-list/static/test-asset-1-filename.js" type="text/javascript"></script>`);
+                    expect(gwResponse).to.include(`<script puzzle-dependency="puzzle-lib" type="text/javascript">puzzleLibScript</script><title>Browsing - boutique-list</title><meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"><link puzzle-asset="test-asset-2-name" rel="stylesheet" href="/boutique-list/static/test-asset-2-filename.css"></head><body><div id="boutique-list" puzzle-fragment="boutique-list" fragment-partial="main">Requested:Url:test</div><script puzzle-asset="test-asset-1-name" src="/boutique-list/static/test-asset-1-filename.js" type="text/javascript"></script>`);
                 }
             }) as any,{});
         });
@@ -680,7 +712,7 @@ describe('Gateway', () => {
             await bffGw.renderFragment({url: 'test'} as any, 'boutique-list', FRAGMENT_RENDER_MODES.PREVIEW, DEFAULT_MAIN_PARTIAL, createExpressMock({
                 send: (gwResponse: string) => {
                     if (!gwResponse) throw new Error('No response from gateway');
-                    expect(gwResponse).to.include(`<script puzzle-dependency="puzzle-lib" type="text/javascript">puzzleLibScript</script><title>Browsing - boutique-list</title><meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"><link puzzle-asset="test-asset-2-name" rel="stylesheet" href="test-asset-2-link.css"></head><body><div id="boutique-list">Requested:Url:test</div><script puzzle-asset="test-asset-1-name" src="test-asset-1-link.js" type="text/javascript"></script>`);
+                    expect(gwResponse).to.include(`<script puzzle-dependency="puzzle-lib" type="text/javascript">puzzleLibScript</script><title>Browsing - boutique-list</title><meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"><link puzzle-asset="test-asset-2-name" rel="stylesheet" href="test-asset-2-link.css"></head><body><div id="boutique-list" puzzle-fragment="boutique-list" fragment-partial="main">Requested:Url:test</div><script puzzle-asset="test-asset-1-name" src="test-asset-1-link.js" type="text/javascript"></script>`);
                 }
             }) as any,{});
         });


### PR DESCRIPTION
#### What's this PR do?

It adds puzzle-fragment and fragment-partial attributes to the fragment preview containers. It should resolve the any issues with css and container query issues especially on fragments with multiple fragments.

#### Where should the reviewer start?

The change set is very straightforward. The reviewer can inspect the updated tests and the new test case for specific to the mentioned requirement.

#### How should this be manually tested?

It can be easily tested by linking this package to a puzzle gateway and preview a fragment:

`<gw-url>/<fragment-name>/<url-for-the-fragment>?__partial=<a-valid-partial-name>`

#### Screenshots (if appropriate)

![Screen Shot 2024-01-05 at 23 57 53](https://github.com/puzzle-js/puzzle-js/assets/46731483/d3c091e6-d2b4-43cc-897f-3a7a83a7baee)



