### PR TITLE
refactor: improve fragment content url generation in storefront server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+# [3.65.0] - 19-02-2024
+### Changed
+- A fragment's name included in a page's URL will not cause the URL to be modified (just like js client logic).
+
 # [3.64.1] - 25-01-2024
 ### Changed
 - Improvements on the fragment preview mode by adding `puzzle-fragment` and `fragment-partial` attributes.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puzzle-js/core",
-  "version": "3.64.1",
+  "version": "3.65.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "logo": "https://image.ibb.co/jM29on/puzzlelogo.png",

--- a/src/fragment.ts
+++ b/src/fragment.ts
@@ -143,7 +143,7 @@ export class FragmentBFF extends Fragment {
       },
       req
     );
-    
+
     if (req.query) {
       delete clearedReq.query[RENDER_MODE_QUERY_NAME];
       delete clearedReq.query[PREVIEW_PARTIAL_QUERY_NAME];
@@ -409,7 +409,7 @@ export class FragmentStorefront extends Fragment {
     delete query.primary;
     delete query.shouldwait;
 
-    const routeRequest = req && parsedRequest ? `${parsedRequest.pathname.replace('/' + this.name, '')}?${querystring.stringify(query)}` : `/?${querystring.stringify(query)}`;
+    const routeRequest = req && parsedRequest ? `${parsedRequest.pathname}?${querystring.stringify(query)}` : `/?${querystring.stringify(query)}`;
 
 
     return httpClient.get(`${this.fragmentUrl}${routeRequest}`, this.name, {


### PR DESCRIPTION
#### What's this PR do?
- Removed an unused logic in storefront server that removes a fragments name if it present in the page url. With this change: a fragment's name included in a page's URL will not cause the URL to be modified (just like js client logic).
#### Where should the reviewer start?
- The change set is straightforward. I think review can inspect client library which works as expected in userland: https://github.com/puzzle-js/puzzle-lib/blob/519940c9e12c53a067bb37a707e71c1264360dae/src/core.ts#L117
#### How should this be manually tested?
- It is tested manually by linking it to a in-prod storefront.
#### Any background context you want to provide?
* When users tries to create a page: they mostly set main fragment and page url same name. Though when this happens: the gateway returns 404 for the fragment content request. When we make the fragment client-async: the page works as expected. This is due to a fragment content creation logic difference between https://github.com/puzzle-js/puzzle-js and https://github.com/puzzle-js/puzzle-lib .

| Name                                                       | Value                                                                                |
|---------------------------------------|------------------------------------------------------|
| Page url                                                   |  `https://localhost:3000/listing/1`                                   |
| Fragment name                                      |  `listing`                                                                             |
| Generated content url in puzzle core (as-is)   | `https://localhost:3000/gw/search/listing/1?...`|
| Generated content url in puzzle lib      | `https://localhost:3000/gw/search/listing/listing/1?...` |

*gw config:*
```js
{
    name: 'listing',
    render: {
      url: ['/listing/:id'],
    },
  },
```

resolves to:`gw/listing/listing/:id`.

With the changes now everything should work together.