### PR TITLE
Implement centralized error handling middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+# [3.65.1] - 20-03-2024
+### Changed
+- Route handlers have been modified to utilize centralized error middleware by forwarding exceptions using a next() call.
+
 # [3.65.0] - 19-02-2024
 ### Changed
 - A fragment's name included in a page's URL will not cause the URL to be modified (just like js client logic).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 # [3.65.1] - 20-03-2024
 ### Changed
-- Route handlers have been modified to utilize centralized error middleware by forwarding exceptions using a next() call.
+- Route handlers have been modified to utilize centralized error middleware by forwarding exceptions using a next() call when 'useExpressErrorForwarding' flag is set. With this change, custom error middleware can be used to handle exceptions in a centralized manner.
 
 # [3.65.0] - 19-02-2024
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@puzzle-js/core",
-  "version": "3.65.0",
+  "version": "3.65.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@puzzle-js/core",
-  "version": "3.64.1",
+  "version": "3.65.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puzzle-js/core",
-  "version": "3.65.0",
+  "version": "3.65.1",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "logo": "https://image.ibb.co/jM29on/puzzlelogo.png",

--- a/src/api.ts
+++ b/src/api.ts
@@ -20,13 +20,13 @@ export class Api {
     }
 
     private controllerWrapper(handler) {
-        return async (req, res) => {
+        return async (req, res, next) => {
             try {
-                await handler(req, res);
+                await handler(req, res, next);
             } catch (e) {
                 console.error("PUZZLE_BFF_HANDLER_UNHANDLED_ERROR");
                 console.log(e);
-                return res.status(500).send();
+                next(e);
             }
         };
     }

--- a/src/api.ts
+++ b/src/api.ts
@@ -19,14 +19,19 @@ export class Api {
         this.prepareHandlers();
     }
 
-    private controllerWrapper(handler) {
+    private controllerWrapper(handler, useExpressErrorForwarding = false) {
         return async (req, res, next) => {
             try {
                 await handler(req, res, next);
             } catch (e) {
+                if (useExpressErrorForwarding) {
+                    next(e);
+                    return;
+                }
+
                 console.error("PUZZLE_BFF_HANDLER_UNHANDLED_ERROR");
                 console.log(e);
-                next(e);
+                return res.status(500).send();
             }
         };
     }
@@ -49,7 +54,7 @@ export class Api {
             const apiHandler = this.config.versions[version];
 
             apiHandler.endpoints.forEach(endpoint => {
-                server.handler.addRoute(`/${API_ROUTE_PREFIX}/${this.config.name}/${version}${endpoint.path}`, endpoint.method, this.controllerWrapper(this.handler[version][endpoint.controller]), endpoint.middlewares);
+                server.handler.addRoute(`/${API_ROUTE_PREFIX}/${this.config.name}/${version}${endpoint.path}`, endpoint.method, this.controllerWrapper(this.handler[version][endpoint.controller], endpoint.useExpressErrorForwarding), endpoint.middlewares);
             });
         });
     }

--- a/src/configurator.ts
+++ b/src/configurator.ts
@@ -24,7 +24,8 @@ const apiEndpointsStructure = struct({
     method: struct.enum(Object.values(HTTP_METHODS)),
     controller: 'string',
     routeCache: 'number?',
-    cacheControl: 'string?'
+    cacheControl: 'string?',
+    useExpressErrorForwarding: 'boolean?'
 });
 
 const customHeaderStructure = struct({

--- a/src/types.ts
+++ b/src/types.ts
@@ -141,6 +141,7 @@ export interface IApiHandler {
     cacheControl?: string;
     routeCache?: number;
     controller: string;
+    useExpressErrorForwarding?: boolean;
 }
 
 export interface IApiVersion {


### PR DESCRIPTION
#### What's this PR do?
* - Implements centralized error handling across the application. By modifying route handlers to use next(e) for error forwarding, this change ensures that all errors are handled consistently and are passed to a centralized error handling middleware.
#### Where should the reviewer start?
* - The reviewer should start their review process at the `src/api.ts` file. If the 'useExpressErrorForwarding' flag is enabled, the logic will be implemented, otherwise the current version will work as is.
#### How should this be manually tested?
* - Trigger various known errors within the application routes to ensure they are caught and handled by the new error middleware.
#### Any background context you want to provide?
* - If there is no error middleware, Express should handle errors with its default error middleware.
